### PR TITLE
Respecting admins and users privacy

### DIFF
--- a/WebfrontCore/Views/Client/Find/Index.cshtml
+++ b/WebfrontCore/Views/Client/Find/Index.cshtml
@@ -20,7 +20,11 @@
                         <color-code value="@client.Name" allow="@ViewBag.EnableColorCodes"></color-code>
                     </a>
                 </div>
-                <div class="col-4 level-color-@client.LevelInt">@client.Level</div>
+                @if (ViewBag.Authorized){
+                    <div class="col-4 level-color-@client.LevelInt">@client.Level</div>
+                }else{
+                    <div class="col-4 level-color-0">User</div>
+                }
                 <div class="col-3 text-right">@client.LastConnectionText</div>
             </div>
         }

--- a/WebfrontCore/Views/Client/Find/Index.cshtml
+++ b/WebfrontCore/Views/Client/Find/Index.cshtml
@@ -45,7 +45,11 @@
                     <color-code value="@client.Name" allow="@ViewBag.EnableColorCodes"></color-code>
                 </a>
             </div>
-            <div class="p-2 level-color-@client.LevelInt">@client.Level</div>
+            @if (ViewBag.Authorized){
+                <div class="col-4 level-color-@client.LevelInt">@client.Level</div>
+            }else{
+                <div class="col-4 level-color-0">User</div>
+            }
             <div class="p-2 text-white-50">@client.LastConnectionText</div>
         </div>
     }

--- a/WebfrontCore/Views/Client/Privileged/Index.cshtml
+++ b/WebfrontCore/Views/Client/Privileged/Index.cshtml
@@ -26,6 +26,6 @@
     </div>
 }else{
     <div class="row">
-        <div class="bg-danger">This section only accessible for logged in users </div>
+        <div class="col-12 text-center bg-danger" style="padding: 10px">This section is only accessible for logged in users </div>
     </div>
 }

--- a/WebfrontCore/Views/Client/Privileged/Index.cshtml
+++ b/WebfrontCore/Views/Client/Privileged/Index.cshtml
@@ -2,7 +2,9 @@
 
 <h4 class="pb-3 text-center ">@ViewBag.Title</h4>
 
-<div class="row border-bottom">
+@if (ViewBag.Authorized)
+{
+    <div class="row border-bottom">
     @{
         foreach (var key in Model.Keys)
         {
@@ -21,4 +23,9 @@
             </div>
         }
     }
-</div>
+    </div>
+}else{
+    <div class="row">
+        <div class="bg-danger">This section only accessible for logged in users </div>
+    </div>
+}

--- a/WebfrontCore/Views/Client/Profile/Index.cshtml
+++ b/WebfrontCore/Views/Client/Profile/Index.cshtml
@@ -142,11 +142,14 @@
     </div>
 </div>
 
-<div class="row d-md-flex pt-2">
-    <div id="profile_events" class="text-muted text-left pl-4 pr-4 pl-md-0 pr-md-0">
-        @await Component.InvokeAsync("ProfileMetaList", new { clientId = Model.ClientId, count = 30, offset = 0, startAt = DateTime.UtcNow, metaType = Model.MetaFilterType })
+@if (ViewBag.Authorized)
+{
+    <div class="row d-md-flex pt-2">
+        <div id="profile_events" class="text-muted text-left pl-4 pr-4 pl-md-0 pr-md-0">
+            @await Component.InvokeAsync("ProfileMetaList", new { clientId = Model.ClientId, count = 30, offset = 0, startAt = DateTime.UtcNow, metaType = Model.MetaFilterType })
+        </div>
     </div>
-</div>
+}
 
 <div class="row">
     <div class="oi oi-chevron-bottom text-center mt-2 btn btn-primary btn-block loader-load-more" title="Load more meta" data-action="unban" aria-hidden="true"></div>

--- a/WebfrontCore/Views/Client/Profile/Index.cshtml
+++ b/WebfrontCore/Views/Client/Profile/Index.cshtml
@@ -74,9 +74,15 @@
         }
         else
         {
-            <div id="profile_level" class="font-weight-bold h4 mb-0 level-color-@Model.LevelInt">
-                @Model.Level
-            </div>
+            if(ViewBag.Authorized){
+                <div id="profile_level" class="font-weight-bold h4 mb-0 level-color-@Model.LevelInt">
+                    @Model.Level
+                </div>
+            }else{
+                <div id="profile_level" class="font-weight-bold h4 mb-0 level-color-0">
+                    User
+                </div>
+            }
         }
     </div>
     @if (ViewBag.Authorized)


### PR DESCRIPTION
At RepZ we discovered we cant hide our iw4m panel address because it plays important role in our unban appeals, But on the other hand, we thought current panel doesn't respect privacy in some ways:

1. Normally admins mask in the game but players could easily find admins in iw4admin panel. Our fork fixes that as much as possible. Only admins (logged in users) can now see other admins in iw4admin panel.
2. We found that its some how against users privacy to let everyone see their message history (aka event history) so we decided to hide it.

1st was very important to us and we believe it maybe something useful for everyone, but 2nd one might be optional.
I understand the way I have fixed these issues may not be the best solution and I wish you implement these options if you reject my fix.