### PR TITLE
Update Pluto T6 Parser

### DIFF
--- a/Plugins/ScriptPlugins/ParserPT6.js
+++ b/Plugins/ScriptPlugins/ParserPT6.js
@@ -3,7 +3,7 @@ var eventParser;
 
 var plugin = {
     author: 'RaidMax, Xerxes',
-    version: 0.8,
+    version: 0.9,
     name: 'Plutonium T6 Parser',
     isParser: true,
 
@@ -36,7 +36,7 @@ var plugin = {
         rconParser.Configuration.Status.AddMapping(104, 5);
         rconParser.Configuration.Status.AddMapping(105, 6);
         
-        eventParser.Configuration.GameDirectory = 't6r\\data';
+        eventParser.Configuration.GameDirectory = 't6';
         eventParser.Configuration.GuidNumberStyle = 7; // Integer
 
         rconParser.Version = 'Call of Duty Multiplayer - Ship COD_T6_S MP build 1.0.44 CL(1759941) CODPCAB2 CEG Fri May 9 19:19:19 2014 win-x86 813e66d5';


### PR DESCRIPTION
Plutonium T6 has deprecated the `t6r/data` folder, in favor of a `t6` folder. 
This PR updates said parser.

Drafting this for now as I am not 100% on if the logs will remain in the game server directory.