### PR TITLE
PlutoIW5 support for the Game Interface and improvements to the GSC part of it.

### DIFF
--- a/GameFiles/README.MD
+++ b/GameFiles/README.MD
@@ -1,0 +1,16 @@
+# Game Interface
+
+Allows integration of IW4M-Admin to GSC, mainly used for special commands that need to use GSC in order to work.
+But can also be used to read / write metadata from / to a profile and to get the player permission level.
+
+
+## Installation PIW5
+
+
+Move `_integration.gsc` to `%localappdata%\Plutonium\storage\iw5\scripts\`
+
+
+## Installation IW4x
+
+
+Move `_integration.gsc` to `IW4x/userraw/scripts`, `IW4x` being the root folder of your game server.

--- a/GameFiles/README.MD
+++ b/GameFiles/README.MD
@@ -4,7 +4,7 @@ Allows integration of IW4M-Admin to GSC, mainly used for special commands that n
 But can also be used to read / write metadata from / to a profile and to get the player permission level.
 
 
-## Installation PIW5
+## Installation Plutonium IW5
 
 
 Move `_integration.gsc` to `%localappdata%\Plutonium\storage\iw5\scripts\`

--- a/GameFiles/_integration.gsc
+++ b/GameFiles/_integration.gsc
@@ -100,6 +100,8 @@ OnPlayerSpawned()
     for ( ;; )
     {
         self waittill( "spawned_player" );
+        self IW5_God();
+        self IW5_NoClip();
         self PlayerConnectEvents();
     }
 }
@@ -268,6 +270,11 @@ InitializeGameMethods()
     if ( isDefined( ::NoClip ) )
     {
         level.overrideMethods["noclip"] = ::NoClip;
+    }
+
+    if (level.eventBus.gamename == "IW5") { //PlutoIW5 only allows Godmode and NoClip if cheats are on..
+        level.overrideMethods["god"] =    ::IW5_God;
+        level.overrideMethods["noclip"] = ::IW5_NoClip;
     }
 }
 
@@ -1004,4 +1011,19 @@ _god( isEnabled )
         self.health = self.savedHealth;
         self.maxhealth = self.savedMaxHealth;
     }
+}
+
+
+IW5_God()
+{
+    SetDvar( "sv_cheats", 1 );
+    self God();
+    SetDvar( "sv_cheats", 0 );
+}
+
+IW5_NoClip()
+{
+    SetDvar( "sv_cheats", 1 );
+    self NoClip();
+    SetDvar( "sv_cheats", 0 );
 }

--- a/GameFiles/_integration.gsc
+++ b/GameFiles/_integration.gsc
@@ -269,16 +269,17 @@ InitializeGameMethods()
     {
         level.overrideMethods["noclip"] = ::NoClip;
     }
-
-    if (level.eventBus.gamename == "IW5") { //PlutoIW5 only allows Godmode and NoClip if cheats are on..
-        level.overrideMethods["god"] =    ::IW5_God;
+	
+    if ( level.eventBus.gamename == "IW5" ) 
+	{ //PlutoIW5 only allows Godmode and NoClip if cheats are on..
+        level.overrideMethods["god"] 	= ::IW5_God;
         level.overrideMethods["noclip"] = ::IW5_NoClip;
     }
 }
 
 UnsupportedFunc()
 { 
-    self IPrintLnBold( "Function isn't supported!" );
+    self IPrintLnBold( "Function is not supported!" );
 }
 
 RequestClientMeta( metaKey )
@@ -745,7 +746,7 @@ LockControlsImpl()
 
     info = [];
     info[ "alertType" ] = "Alert!";
-    info[ "message" ] = "You've been frozen!";
+    info[ "message" ] = "You have been frozen!";
     
     self AlertImpl( undefined, info );
 

--- a/GameFiles/_integration.gsc
+++ b/GameFiles/_integration.gsc
@@ -1,7 +1,6 @@
 #include common_scripts\utility;
 #include maps\mp\_utility;
 #include maps\mp\gametypes\_hud_util;
-//#include maps\mp\gametypes\_playerlogic;
 
 init()
 {
@@ -12,7 +11,7 @@ init()
     level.eventBus.failKey      = "fail";
     level.eventBus.timeoutKey   = "timeout";
     level.eventBus.timeout      = 30;
-    level.eventBus.gamename     = getDvar("gamename"); // We want to do a few small detail different on IW5 compared to IW4, nothing where 2 files would make sense.
+    level.eventBus.gamename     = getDvar( "gamename" ); // We want to do a few small detail different on IW5 compared to IW4, nothing where 2 files would make sense.
     
     level.clientDataKey = "clientData";
 
@@ -40,16 +39,16 @@ init()
     level.clientCommandCallbacks = [];
     level.clientCommandRusAsTarget = [];
     //Populate collections above
-    addClientCommand("GiveWeapon",   true,  ::GiveWeaponImpl);
-    addClientCommand("TakeWeapons",  true,  ::TakeWeaponsImpl);
-    addClientCommand("SwitchTeams",  true,  ::TeamSwitchImpl);
-    addClientCommand("Hide",         false, ::HideImpl);
-    addClientCommand("Unhide",       false, ::UnhideImpl);
-    addClientCommand("Alert",        true,  ::AlertImpl);
-    addClientCommand("Goto",         false, ::GotoImpl);
-    addClientCommand("Kill",         true,  ::KillImpl);
-    addClientCommand("SetSpectator", true,  ::SetSpectatorImpl);
-    addClientCommand("NightMode",    false, ::NightModeImpl); //This really should be a level command
+    addClientCommand( "GiveWeapon",   true,  ::GiveWeaponImpl );
+    addClientCommand( "TakeWeapons",  true,  ::TakeWeaponsImpl );
+    addClientCommand( "SwitchTeams",  true,  ::TeamSwitchImpl );
+    addClientCommand( "Hide",         false, ::HideImpl );
+    addClientCommand( "Unhide",       false, ::UnhideImpl );
+    addClientCommand( "Alert",        true,  ::AlertImpl );
+    addClientCommand( "Goto",         false, ::GotoImpl );
+    addClientCommand( "Kill",         true,  ::KillImpl );
+    addClientCommand( "SetSpectator", true,  ::SetSpectatorImpl );
+    addClientCommand( "NightMode",    false, ::NightModeImpl ); //This really should be a level command
     
     if ( GetDvarInt( "sv_iw4madmin_integration_enabled" ) != 1 )
     {
@@ -505,21 +504,21 @@ NotifyClientEvent( eventInfo )
     if ( level.iw4adminIntegrationDebug == 1 )
     {
         IPrintLn( "NotifyClientEvent->" + event.data );
-        if(int(eventInfo[3]) != -1 && !isDefined(origin))
+        if( int( eventInfo[3] ) != -1 && !isDefined( origin ) )
         {
-            IPrintLn("origin is null but the slot id is " + int(eventInfo[3]));
+            IPrintLn( "origin is null but the slot id is " + int( eventInfo[3] ) );
         }
-        if(int(eventInfo[4]) != -1 && !isDefined(target))
+        if( int( eventInfo[4] ) != -1 && !isDefined( target ) )
         {
-            IPrintLn("target is null but the slot id is " + int(eventInfo[4]));
+            IPrintLn( "target is null but the slot id is " + int( eventInfo[4] ) );
         }
     }
 
-    if(isDefined(target))
+    if( isDefined( target ) )
     {
         client = event.target;
     }
-    else if(isDefined(origin))
+    else if( isDefined( origin ) )
     {
         client = event.origin;
     }
@@ -529,6 +528,7 @@ NotifyClientEvent( eventInfo )
         {
             IPrintLn( "Neither origin or target are set but we are a Client Event, aborting" );
         }
+        
         return;
     }
     client.event = event;
@@ -536,7 +536,7 @@ NotifyClientEvent( eventInfo )
     level notify( level.eventTypes.localClientEvent, client );
 }
 
-getPlayerFromClientNum( clientNum )
+GetPlayerFromClientNum( clientNum )
 {
 	if ( clientNum < 0 )
 		return undefined;
@@ -544,18 +544,21 @@ getPlayerFromClientNum( clientNum )
 	for ( i = 0; i < level.players.size; i++ )
 	{
 		if ( level.players[i] getEntityNumber() == clientNum )
+        {
 			return level.players[i];
+        }
 	}
 	return undefined;
 }
 
-addClientCommand(cmd, runAsTarget, callback, overwrite)
+AddClientCommand( commandName, shouldRunAsTarget, callback, shouldOverwrite )
 {
-    if (isDefined(level.clientCommandCallbacks[cmd]) && isDefined(overwrite) && !overwrite) {
+    if ( isDefined( level.clientCommandCallbacks[commandName] ) && isDefined( shouldOverwrite ) && !shouldOverwrite ) {
+
         return;
     }
-    level.clientCommandCallbacks[cmd] = callback;
-    level.clientCommandRusAsTarget[cmd] = runAsTarget == true; //might speed up things later in case someone gives us a string or number instead of a boolean
+    level.clientCommandCallbacks[commandName] = callback;
+    level.clientCommandRusAsTarget[commandName] = shouldRunAsTarget == true; //might speed up things later in case someone gives us a string or number instead of a boolean
 }
 
 //////////////////////////////////
@@ -604,14 +607,14 @@ OnExecuteCommand( event )
     data = ParseDataString( event.data );
     response = "";
 
-    cmd = level.clientCommandCallbacks[event.subtype];
+    command = level.clientCommandCallbacks[event.subtype];
     runAsTarget = level.clientCommandRusAsTarget[event.subtype];
-    context = event.origin;
-    if (runAsTarget) {
-        context = event.target;
+    executionContextEntity = event.origin;
+    if ( runAsTarget ) {
+        executionContextEntity = event.target;
     }
-    if (isDefined(cmd)) {
-        response = context [[cmd]](event, data);
+    if ( isDefined( command ) ) {
+        response = executionContextEntity [[command]]( event, data );
     }
     else if ( level.iw4adminIntegrationDebug == 1 )
     {
@@ -741,16 +744,16 @@ UnhideImpl()
 
 AlertImpl( event, data )
 {
-    if (level.eventBus.gamename == "IW4") {
+    if ( level.eventBus.gamename == "IW4" ) {
         self thread maps\mp\gametypes\_hud_message::oldNotifyMessage( data["alertType"], data["message"], "compass_waypoint_target", ( 1, 0, 0 ), "ui_mp_nukebomb_timer", 7.5 );
     }
-    if (level.eventBus.gamename == "IW5") { //IW5's notification are a bit different...
+    if ( level.eventBus.gamename == "IW5" ) { //IW5's notification are a bit different...
         self thread maps\mp\gametypes\_hud_message::oldNotifyMessage( data["alertType"], data["message"], undefined, ( 1, 0, 0 ), "ui_mp_nukebomb_timer", 7.5 );
     }
     return "Sent alert to " + self.name; 
 }
 
-GotoImpl(event, data)
+GotoImpl( event, data )
 {
     if ( IsDefined( event.target ) )
     {

--- a/GameFiles/_integration.gsc
+++ b/GameFiles/_integration.gsc
@@ -100,8 +100,6 @@ OnPlayerSpawned()
     for ( ;; )
     {
         self waittill( "spawned_player" );
-        self IW5_God();
-        self IW5_NoClip();
         self PlayerConnectEvents();
     }
 }

--- a/GameFiles/_integration.gsc
+++ b/GameFiles/_integration.gsc
@@ -899,7 +899,7 @@ PlayerToMeImpl( event )
 {
     if ( !IsAlive( self ) )
     {
-        return self.name + " is not alive";;
+        return self.name + " is not alive";
     }
 
     self SetOrigin( event.origin GetOrigin() );

--- a/IW4MAdmin.sln
+++ b/IW4MAdmin.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.txt = version.txt
 		DeploymentFiles\UpdateIW4MAdmin.ps1 = DeploymentFiles\UpdateIW4MAdmin.ps1
 		DeploymentFiles\UpdateIW4MAdmin.sh = DeploymentFiles\UpdateIW4MAdmin.sh
-		GameFiles\IW4x\userraw\scripts\_integration.gsc = GameFiles\IW4x\userraw\scripts\_integration.gsc
+		GameFiles\_integration.gsc = GameFiles\_integration.gsc
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedLibraryCore", "SharedLibraryCore\SharedLibraryCore.csproj", "{AA0541A2-8D51-4AD9-B0AC-3D1F5B162481}"

--- a/Plugins/ScriptPlugins/GameInterface.js
+++ b/Plugins/ScriptPlugins/GameInterface.js
@@ -130,6 +130,72 @@ let commands = [{
         }
     },
     {
+        name: 'lockcontrols',
+        description: 'locks target player\'s controls',
+        alias: 'lc',
+        permission: 'Administrator',
+        targetRequired: true,
+        arguments: [{
+            name: 'player',
+            required: true
+        }],
+        supportedGames: ['IW4'],
+        execute: (gameEvent) => {
+            if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
+                return;
+            }
+            sendScriptCommand(gameEvent.Owner, 'LockControls', gameEvent.Origin, gameEvent.Target, undefined);
+        }
+    },
+    {
+        name: 'unlockcontrols',
+        description: 'unlocks target player\'s controls',
+        alias: 'ulc',
+        permission: 'Administrator',
+        targetRequired: true,
+        arguments: [{
+            name: 'player',
+            required: true
+        }],
+        supportedGames: ['IW4'],
+        execute: (gameEvent) => {
+            if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
+                return;
+            }
+            sendScriptCommand(gameEvent.Owner, 'UnlockControls', gameEvent.Origin, gameEvent.Target, undefined);
+        }
+    },
+    {
+        name: 'noclip',
+        description: 'enable noclip on yourself ingame',
+        alias: 'nc',
+        permission: 'SeniorAdmin',
+        targetRequired: false,
+        arguments: [],
+        supportedGames: ['IW4'],
+        execute: (gameEvent) => {
+            if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
+                return;
+            }
+            sendScriptCommand(gameEvent.Owner, 'NoClip', gameEvent.Origin, gameEvent.Origin, undefined);
+        }
+    },
+    {
+        name: 'noclipoff',
+        description: 'disable noclip on yourself ingame',
+        alias: 'nco',
+        permission: 'SeniorAdmin',
+        targetRequired: false,
+        arguments: [],
+        supportedGames: ['IW4'],
+        execute: (gameEvent) => {
+            if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
+                return;
+            }
+            sendScriptCommand(gameEvent.Owner, 'NoClipOff', gameEvent.Origin, gameEvent.Origin, undefined);
+        }
+    },
+    {
         name: 'hide',
         description: 'hide yourself ingame',
         alias: 'hi',
@@ -200,6 +266,24 @@ let commands = [{
                 return;
             }
             sendScriptCommand(gameEvent.Owner, 'Goto', gameEvent.Origin, gameEvent.Target, undefined);
+        }
+    },
+    {
+        name: 'playertome',
+        description: 'teleport a player to you',
+        alias: 'p2m',
+        permission: 'SeniorAdmin',
+        targetRequired: true,
+        arguments: [{
+            name: 'player',
+            required: true
+        }],
+        supportedGames: ['IW4', 'IW5'],
+        execute: (gameEvent) => {
+            if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
+                return;
+            }
+            sendScriptCommand(gameEvent.Owner, 'PlayerToMe', gameEvent.Origin, gameEvent.Target, undefined);
         }
     },
     {
@@ -489,7 +573,7 @@ const pollForEvents = server => {
         const nextMessage = state.queuedMessages.splice(0, 1);
         setDvar(server, outDvar, nextMessage, onSetDvar);
     }
- 
+
     if (state.waitingOnOutput) {
         getDvar(server, outDvar, onReceivedDvar);
     }

--- a/Plugins/ScriptPlugins/GameInterface.js
+++ b/Plugins/ScriptPlugins/GameInterface.js
@@ -85,7 +85,7 @@ let commands = [{
             name: 'weapon name',
             required: true
         }],
-    supportedGames: ['IW4'],
+    supportedGames: ['IW4', 'IW5'],
     execute: (gameEvent) => {
         if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
             return;
@@ -103,7 +103,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -121,7 +121,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -136,7 +136,7 @@ let commands = [{
         permission: 'SeniorAdmin',
         targetRequired: false,
         arguments: [],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -151,7 +151,7 @@ let commands = [{
         permission: 'SeniorAdmin',
         targetRequired: false,
         arguments: [],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -173,7 +173,7 @@ let commands = [{
                 name: 'message',
                 required: true
             }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -194,7 +194,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -220,7 +220,7 @@ let commands = [{
                 name: 'z',
                 required: true
             }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -244,7 +244,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -259,7 +259,7 @@ let commands = [{
         permission: 'SeniorAdmin',
         targetRequired: false,
         arguments: [],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -277,7 +277,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;

--- a/Plugins/ScriptPlugins/GameInterface.js
+++ b/Plugins/ScriptPlugins/GameInterface.js
@@ -139,7 +139,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -157,7 +157,7 @@ let commands = [{
             name: 'player',
             required: true
         }],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -172,7 +172,7 @@ let commands = [{
         permission: 'SeniorAdmin',
         targetRequired: false,
         arguments: [],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;
@@ -187,7 +187,7 @@ let commands = [{
         permission: 'SeniorAdmin',
         targetRequired: false,
         arguments: [],
-        supportedGames: ['IW4'],
+        supportedGames: ['IW4', 'IW5'],
         execute: (gameEvent) => {
             if (!validateEnabled(gameEvent.Owner, gameEvent.Origin)) {
                 return;


### PR DESCRIPTION
* Adds compatibility with PlutoIW5 with minimal changes.
* Fixes issues when commands are called from the web interface when the used profile is not on the server.
    * New Debug output when the target or origin of a command is sent by IW4MAdmin but not found in-game.
    * Commands that can be run on the context of the target are now run in it.
* Simplifies the command registration and execution.
    * Got rid of the huge switch block.
    * Introduced addClientCommand to register new commands for example
        * `addClientCommand("SwitchTeams",  true,  ::TeamSwitchImpl);`
        * `addClientCommand("Hide",         false, ::HideImpl);`
    * Callbacks are called with the full event object and the parsed data as parameters to allow maximum flexibility.
* Introduced level.eventBus.gamename to know which game we are to add minor changes.

Changes are tested on my servers (IW5 and IW4) and I'm currently waiting on feedback from the other IW4MAdmin tester.