### PR TITLE
Improvements to game scripts

### DIFF
--- a/GameFiles/IW4x/userraw/scripts/_customcallbacks.gsc
+++ b/GameFiles/IW4x/userraw/scripts/_customcallbacks.gsc
@@ -29,8 +29,9 @@ onPlayerConnect( player )
 	for( ;; )
 	{
 		level waittill( "connected", player );	
-		player setClientDvar("cl_autorecord", 1);
-		player setClientDvar("cl_demosKeep", 200);
+		player setClientDvars( "cl_autorecord", 1,
+					"cl_demosKeep", 200 );
+
 		player thread waitForFrameThread();
 		player thread waitForAttack();
 	}
@@ -60,7 +61,7 @@ getHttpString( url )
 
 runRadarUpdates()
 {
-	interval = int(getDvar("sv_printradar_updateinterval"));
+	interval = getDvarInt( "sv_printradar_updateinterval", 500 );
 
 	for ( ;; )
 	{
@@ -191,7 +192,7 @@ waitForAdditionalAngles( logString, beforeFrameCount, afterFrameCount )
 		i++;
 	}
 
-	lastAttack = int(getTime()) - int(self.lastAttackTime);
+	lastAttack = getTime() - self.lastAttackTime;
 	isAlive = isAlive(self);
 
 	logPrint(logString + ";" + anglesStr + ";" + isAlive + ";" + lastAttack + "\n" ); 

--- a/GameFiles/IW5/storage/iw5/scripts/_customcallbacks.gsc
+++ b/GameFiles/IW5/storage/iw5/scripts/_customcallbacks.gsc
@@ -53,7 +53,7 @@ waitForAttack()
 
 runRadarUpdates()
 {
-	interval = int(getDvar("sv_printradar_updateinterval"));
+	interval = getDvarInt( "sv_printradar_updateinterval", 500 );
 
 	for ( ;; )
 	{
@@ -183,7 +183,7 @@ waitForAdditionalAngles( logString, beforeFrameCount, afterFrameCount )
 		i++;
 	}
 
-	lastAttack = int(getTime()) - int(self.lastAttackTime);
+	lastAttack = getTime() - self.lastAttackTime;
 	isAlive = isAlive(self);
 
 	logPrint(logString + ";" + anglesStr + ";" + isAlive + ";" + lastAttack + "\n" ); 

--- a/GameFiles/PT6/storage/t6/scripts/mp/_customcallbacks.gsc.src
+++ b/GameFiles/PT6/storage/t6/scripts/mp/_customcallbacks.gsc.src
@@ -60,7 +60,7 @@ waitForAttack()
 
 runRadarUpdates()
 {
-	interval = int(getDvar("sv_printradar_updateinterval"));
+	interval = getDvarInt( "sv_printradar_updateinterval" );
 
 	for ( ;; )
 	{
@@ -190,7 +190,7 @@ waitForAdditionalAngles( logString, beforeFrameCount, afterFrameCount )
 		i++;
 	}
 
-	lastAttack = int(getTime()) - int(self.lastAttackTime);
+	lastAttack = getTime() - self.lastAttackTime;
 	isAlive = isAlive(self);
 
 	logPrint(logString + ";" + anglesStr + ";" + isAlive + ";" + lastAttack + "\n" ); 


### PR DESCRIPTION
- `setClientDvars` is to be preferred over `setClientDvar` when there is the need to set more than one client dvar. The reason is that only one server command is sent instead of multiples. That may cause issues, especially when other game scripts are causing other server commands to be sent. In short, the fewer server commands are sent the better.
- `getDvarInt` is to be preferred over `int( getDvar() )`. The reason is that `getDvarInt` already fully supports casting variables to the desired type internally. The *second* `int()` is redundant. Additionally, the IW variant of `getDvarInt` supports a default value that is returned in case the dvar was not registered or other errors were to arise when calling `getDvarInt`. This can't be done with a regular `getDvar`.
- `getTime()` always returns an integer type and `self.lastAttackTime` is always assigned an integer type therefore the casting to int before subtraction is redundant as well.