### PR TITLE
Fix Threading Duplicate for Mute Penalty & Added !MuteInfo & Fix PM

### DIFF
--- a/Plugins/Mute/Commands/MuteInfoCommand.cs
+++ b/Plugins/Mute/Commands/MuteInfoCommand.cs
@@ -1,0 +1,50 @@
+using Data.Models.Client;
+using Humanizer;
+using SharedLibraryCore;
+using SharedLibraryCore.Commands;
+using SharedLibraryCore.Configuration;
+using SharedLibraryCore.Interfaces;
+
+namespace Mute.Commands;
+
+public class MuteInfoCommand : Command
+{
+    public MuteInfoCommand(CommandConfiguration config, ITranslationLookup translationLookup) : base(config,
+        translationLookup)
+    {
+        Name = "muteinfo";
+        Description = translationLookup["PLUGINS_MUTE_COMMANDS_MUTEINFO_DESC"];
+        Alias = "mi";
+        Permission = EFClient.Permission.Moderator;
+        RequiresTarget = true;
+        SupportedGames = Plugin.SupportedGames;
+        Arguments = new[]
+        {
+            new CommandArgument
+            {
+                Name = translationLookup["COMMANDS_ARGS_PLAYER"],
+                Required = true
+            }
+        };
+    }
+
+    public override async Task ExecuteAsync(GameEvent gameEvent)
+    {
+        var currentMuteMeta = await Plugin.MuteManager.GetCurrentMuteState(gameEvent.Target);
+        switch (currentMuteMeta.MuteState)
+        {
+            case MuteState.Muted when currentMuteMeta.Expiration is null:
+                gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_COMMANDS_MUTEINFO_SUCCESS"]
+                    .FormatExt(gameEvent.Target.Name, currentMuteMeta.Reason));
+                return;
+            case MuteState.Muted when currentMuteMeta.Expiration.HasValue && currentMuteMeta.Expiration.Value > DateTime.UtcNow:
+                var remainingTime = (currentMuteMeta.Expiration.Value - DateTime.UtcNow).HumanizeForCurrentCulture();
+                gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_COMMANDS_MUTEINFO_TM_SUCCESS"]
+                    .FormatExt(gameEvent.Target.Name, currentMuteMeta.Reason, remainingTime));
+                return;
+            default:
+                gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_COMMANDS_MUTEINFO_NONE"]);
+                break;
+        }
+    }
+}

--- a/Plugins/Mute/MuteManager.cs
+++ b/Plugins/Mute/MuteManager.cs
@@ -98,6 +98,11 @@ public class MuteManager
         if (clientMuteMeta.MuteState is MuteState.Unmuted && clientMuteMeta.CommandExecuted) return false;
         if (!target.IsIngame && clientMuteMeta.MuteState is MuteState.Unmuting) return false;
 
+        if (clientMuteMeta.MuteState is not MuteState.Unmuting)
+        {
+            await CreatePenalty(MuteState.Unmuted, origin, target, DateTime.UtcNow, reason);
+        }
+
         clientMuteMeta = new MuteStateMeta
         {
             Expiration = DateTime.UtcNow,
@@ -106,11 +111,6 @@ public class MuteManager
             CommandExecuted = false
         };
         await WritePersistentData(target, clientMuteMeta);
-
-        if (clientMuteMeta.MuteState is not MuteState.Unmuting)
-        {
-            await CreatePenalty(MuteState.Unmuted, origin, target, DateTime.UtcNow, reason);
-        }
 
         // Handle game command
         var client = server.GetClientsAsList().FirstOrDefault(client => client.NetworkId == target.NetworkId);

--- a/Plugins/Mute/Plugin.cs
+++ b/Plugins/Mute/Plugin.cs
@@ -119,7 +119,16 @@ public class Plugin : IPlugin
         manager.CommandInterceptors.Add(gameEvent =>
         {
             if (gameEvent.Extra is not Command command)
+            {
                 return true;
+            }
+
+            var muteMeta = MuteManager.GetCurrentMuteState(gameEvent.Origin).GetAwaiter().GetResult();
+            if (muteMeta.MuteState is not MuteState.Muted)
+            {
+                return true;
+            }
+
             return !DisabledCommands.Contains(command.GetType().Name) && !command.IsBroadcast;
         });
 

--- a/Plugins/Mute/Plugin.cs
+++ b/Plugins/Mute/Plugin.cs
@@ -38,9 +38,6 @@ public class Plugin : IPlugin
 
         switch (gameEvent.Type)
         {
-            case GameEvent.EventType.Command:
-
-                break;
             case GameEvent.EventType.Join:
                 // Check if user has any meta set, else ignore (unmuted)
                 var muteMetaJoin = await MuteManager.GetCurrentMuteState(gameEvent.Origin);


### PR DESCRIPTION
Resolve unmuting state double penalties (Offline unmuting doubles up the unmute penalty)
Resolve duplicate migration (Threading fix)
Resolve Command Interceptor logic in Mute
Added MuteInfo command so you can check the state of someone's mute in-game.
```
!muteinfo (!mi) <target>
```
```
PLUGINS_MUTE_COMMANDS_MUTEINFO_DESC = get information about a mute for a client
PLUGINS_MUTE_COMMANDS_MUTEINFO_NONE = No active mute was found for that player
PLUGINS_MUTE_COMMANDS_MUTEINFO_SUCCESS = {{targetName}}(Color::White) was permanently muted for {{muteReason}}
PLUGINS_MUTE_COMMANDS_MUTEINFO_TM_SUCCESS = {{targetName}}(Color::White) was temporarily muted for {{offenseReason}}(Color::White) ({{time}} remaining)
```