### PR TITLE
Mute Banner for Profile & Prevent Self-Target & Correctly Expire Early Unmutes

### DIFF
--- a/Plugins/Mute/Commands/MuteCommand.cs
+++ b/Plugins/Mute/Commands/MuteCommand.cs
@@ -34,6 +34,12 @@ public class MuteCommand : Command
 
     public override async Task ExecuteAsync(GameEvent gameEvent)
     {
+        if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
+        {
+            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            return;
+        }
+
         if (await Plugin.MuteManager.Mute(gameEvent.Owner, gameEvent.Origin, gameEvent.Target, null, gameEvent.Data))
         {
             gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_COMMANDS_MUTE_MUTED"]

--- a/Plugins/Mute/Commands/MuteCommand.cs
+++ b/Plugins/Mute/Commands/MuteCommand.cs
@@ -36,7 +36,7 @@ public class MuteCommand : Command
     {
         if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
         {
-            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            gameEvent.Origin.Tell(_translationLookup["COMMANDS_DENY_SELF_TARGET"]);
             return;
         }
 

--- a/Plugins/Mute/Commands/TempMuteCommand.cs
+++ b/Plugins/Mute/Commands/TempMuteCommand.cs
@@ -44,7 +44,7 @@ public class TempMuteCommand : Command
     {
         if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
         {
-            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            gameEvent.Origin.Tell(_translationLookup["COMMANDS_DENY_SELF_TARGET"]);
             return;
         }
         

--- a/Plugins/Mute/Commands/TempMuteCommand.cs
+++ b/Plugins/Mute/Commands/TempMuteCommand.cs
@@ -42,6 +42,12 @@ public class TempMuteCommand : Command
 
     public override async Task ExecuteAsync(GameEvent gameEvent)
     {
+        if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
+        {
+            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            return;
+        }
+        
         var match = Regex.Match(gameEvent.Data, TempBanRegex);
         if (match.Success)
         {

--- a/Plugins/Mute/Commands/UnmuteCommand.cs
+++ b/Plugins/Mute/Commands/UnmuteCommand.cs
@@ -34,6 +34,12 @@ public class UnmuteCommand : Command
 
     public override async Task ExecuteAsync(GameEvent gameEvent)
     {
+        if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
+        {
+            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            return;
+        }
+
         if (await Plugin.MuteManager.Unmute(gameEvent.Owner, gameEvent.Origin, gameEvent.Target, gameEvent.Data))
         {
             gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_COMMANDS_UNMUTE_UNMUTED"]

--- a/Plugins/Mute/Commands/UnmuteCommand.cs
+++ b/Plugins/Mute/Commands/UnmuteCommand.cs
@@ -36,7 +36,7 @@ public class UnmuteCommand : Command
     {
         if (gameEvent.Origin.ClientId == gameEvent.Target.ClientId)
         {
-            gameEvent.Origin.Tell(_translationLookup["PLUGINS_MUTE_SELF_TARGET"]);
+            gameEvent.Origin.Tell(_translationLookup["COMMANDS_DENY_SELF_TARGET"]);
             return;
         }
 

--- a/Plugins/Mute/MuteManager.cs
+++ b/Plugins/Mute/MuteManager.cs
@@ -103,7 +103,7 @@ public class MuteManager
         if (clientMuteMeta.MuteState is MuteState.Unmuted && clientMuteMeta.CommandExecuted) return false;
         if (!target.IsIngame && clientMuteMeta.MuteState is MuteState.Unmuting) return false;
 
-        if (clientMuteMeta.MuteState is not MuteState.Unmuting || origin.ClientId != 1)
+        if (clientMuteMeta.MuteState is not MuteState.Unmuting && origin.ClientId != 1)
         {
             await CreatePenalty(MuteState.Unmuted, origin, target, DateTime.UtcNow, reason);
         }
@@ -149,8 +149,9 @@ public class MuteManager
         await using var context = _databaseContextFactory.CreateContext();
         var mutePenalties = await context.Penalties
             .Where(penalty => penalty.OffenderId == client.ClientId &&
-                penalty.Type == EFPenalty.PenaltyType.Mute || penalty.Type == EFPenalty.PenaltyType.TempMute &&
-                penalty.Expires == null || penalty.Expires > DateTime.UtcNow)
+                              (penalty.Type == EFPenalty.PenaltyType.Mute ||
+                               penalty.Type == EFPenalty.PenaltyType.TempMute) &&
+                              (penalty.Expires == null || penalty.Expires > DateTime.UtcNow))
             .ToListAsync();
 
         foreach (var mutePenalty in mutePenalties)

--- a/Plugins/Mute/MuteManager.cs
+++ b/Plugins/Mute/MuteManager.cs
@@ -98,7 +98,7 @@ public class MuteManager
         if (clientMuteMeta.MuteState is MuteState.Unmuted && clientMuteMeta.CommandExecuted) return false;
         if (!target.IsIngame && clientMuteMeta.MuteState is MuteState.Unmuting) return false;
 
-        if (clientMuteMeta.MuteState is not MuteState.Unmuting)
+        if (clientMuteMeta.MuteState is not MuteState.Unmuting || origin.ClientId != 1)
         {
             await CreatePenalty(MuteState.Unmuted, origin, target, DateTime.UtcNow, reason);
         }

--- a/Plugins/Mute/MuteStateMeta.cs
+++ b/Plugins/Mute/MuteStateMeta.cs
@@ -4,7 +4,7 @@ namespace Mute;
 
 public class MuteStateMeta
 {
-    public string Reason { get; set; } = string.Empty;
+    public string? Reason { get; set; }
     public DateTime? Expiration { get; set; }
     public MuteState MuteState { get; set; }
     [JsonIgnore] public bool CommandExecuted { get; set; }

--- a/Plugins/Mute/Plugin.cs
+++ b/Plugins/Mute/Plugin.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Data.Abstractions;
+using Microsoft.Extensions.Logging;
 using Mute.Commands;
 using SharedLibraryCore;
 using SharedLibraryCore.Commands;
@@ -12,7 +13,7 @@ namespace Mute;
 public class Plugin : IPlugin
 {
     public string Name => "Mute";
-    public float Version => (float) Utilities.GetVersionAsDouble();
+    public float Version => (float)Utilities.GetVersionAsDouble();
     public string Author => "Amos";
 
     public const string MuteKey = "IW4MMute";
@@ -24,12 +25,12 @@ public class Plugin : IPlugin
     private readonly IRemoteCommandService _remoteCommandService;
     private static readonly string MuteInteraction = "Webfront::Profile::Mute";
 
-    public Plugin(ILogger<Plugin> logger, IMetaServiceV2 metaService, IInteractionRegistration interactionRegistration,
-        ITranslationLookup translationLookup, IRemoteCommandService remoteCommandService)
+    public Plugin(ILogger<Plugin> logger, IInteractionRegistration interactionRegistration,
+        IRemoteCommandService remoteCommandService, IServiceProvider serviceProvider)
     {
         _interactionRegistration = interactionRegistration;
         _remoteCommandService = remoteCommandService;
-        MuteManager = new MuteManager(metaService, translationLookup, logger);
+        MuteManager = new MuteManager(serviceProvider);
     }
 
     public async Task OnEventAsync(GameEvent gameEvent, Server server)
@@ -134,7 +135,7 @@ public class Plugin : IPlugin
 
         _interactionRegistration.RegisterInteraction(MuteInteraction, async (targetClientId, game, token) =>
         {
-            if (!targetClientId.HasValue || game.HasValue && !SupportedGames.Contains((Server.Game) game.Value))
+            if (!targetClientId.HasValue || game.HasValue && !SupportedGames.Contains((Server.Game)game.Value))
             {
                 return null;
             }
@@ -162,7 +163,7 @@ public class Plugin : IPlugin
             Name = "Reason",
             Label = Utilities.CurrentLocalization.LocalizationIndex["WEBFRONT_ACTION_LABEL_REASON"],
             Type = "text",
-            Values = (Dictionary<string, string>?) null
+            Values = (Dictionary<string, string>?)null
         };
 
         var durationInput = new
@@ -170,7 +171,7 @@ public class Plugin : IPlugin
             Name = "Duration",
             Label = Utilities.CurrentLocalization.LocalizationIndex["WEBFRONT_ACTION_LABEL_DURATION"],
             Type = "select",
-            Values = (Dictionary<string, string>?) new Dictionary<string, string>
+            Values = (Dictionary<string, string>?)new Dictionary<string, string>
             {
                 {"5m", TimeSpan.FromMinutes(5).HumanizeForCurrentCulture()},
                 {"30m", TimeSpan.FromMinutes(30).HumanizeForCurrentCulture()},

--- a/Plugins/Mute/Plugin.cs
+++ b/Plugins/Mute/Plugin.cs
@@ -57,7 +57,7 @@ public class Plugin : IPlugin
                     case MuteState.Unmuting:
                         // Handle unmute of unmuted players.
                         await MuteManager.Unmute(server, Utilities.IW4MAdminClient(), gameEvent.Origin,
-                            muteMetaJoin.Reason);
+                            muteMetaJoin.Reason ?? string.Empty);
                         gameEvent.Origin.Tell(Utilities.CurrentLocalization
                             .LocalizationIndex["PLUGINS_MUTE_COMMANDS_UNMUTE_TARGET_UNMUTED"]
                             .FormatExt(muteMetaJoin.Reason));

--- a/SharedLibraryCore/Services/PenaltyService.cs
+++ b/SharedLibraryCore/Services/PenaltyService.cs
@@ -131,7 +131,7 @@ namespace SharedLibraryCore.Services
         }
 
         private static readonly EFPenalty.PenaltyType[] LinkedPenalties =
-            { EFPenalty.PenaltyType.Ban, EFPenalty.PenaltyType.Flag, EFPenalty.PenaltyType.TempBan };
+            { EFPenalty.PenaltyType.Ban, EFPenalty.PenaltyType.Flag, EFPenalty.PenaltyType.TempBan, EFPenalty.PenaltyType.TempMute, EFPenalty.PenaltyType.Mute };
 
         private static readonly Expression<Func<EFPenalty, bool>> Filter = p =>
             LinkedPenalties.Contains(p.Type) && p.Active && (p.Expires == null || p.Expires > DateTime.UtcNow);

--- a/WebfrontCore/Controllers/Client/ClientController.cs
+++ b/WebfrontCore/Controllers/Client/ClientController.cs
@@ -162,7 +162,12 @@ namespace WebfrontCore.Controllers
                 });
             }
 
-            clientDto.ActivePenalty = activePenalties.OrderByDescending(_penalty => _penalty.Type).FirstOrDefault();
+            clientDto.ActivePenalty = activePenalties.MaxBy(penalty => penalty.Type switch
+            {
+                EFPenalty.PenaltyType.TempMute => 0,
+                EFPenalty.PenaltyType.Mute => 1,
+                _ => (int)penalty.Type
+            });
             clientDto.Meta.AddRange(Authorized ? meta : meta.Where(m => !m.IsSensitive));
 
             var strippedName = clientDto.Name.StripColors();

--- a/WebfrontCore/Controllers/Client/ClientController.cs
+++ b/WebfrontCore/Controllers/Client/ClientController.cs
@@ -162,6 +162,7 @@ namespace WebfrontCore.Controllers
                 });
             }
 
+            // Reducing the enum value for Temp/Mute so bans appear in client banner first
             clientDto.ActivePenalty = activePenalties.MaxBy(penalty => penalty.Type switch
             {
                 EFPenalty.PenaltyType.TempMute => 0,

--- a/WebfrontCore/Views/Client/Profile/Index.cshtml
+++ b/WebfrontCore/Views/Client/Profile/Index.cshtml
@@ -21,6 +21,8 @@
             EFPenalty.PenaltyType.Ban => "alert-danger",
             EFPenalty.PenaltyType.Flag => "alert-secondary",
             EFPenalty.PenaltyType.TempBan => "alert-secondary",
+            EFPenalty.PenaltyType.TempMute => "alert-secondary",
+            EFPenalty.PenaltyType.Mute => "alert-secondary",
             _ => "alert"
         };
     }
@@ -367,7 +369,7 @@
         });
     }
 
-    if ((Model.LevelInt < (int)ViewBag.User.Level && !Model.HasActivePenalty || isTempBanned) && ViewBag.Authorized)
+    if ((Model.LevelInt < (int)ViewBag.User.Level && !isPermBanned || isTempBanned) && ViewBag.Authorized)
     {
         menuItems.Items.Add(new SideContextMenuItem
         {
@@ -379,7 +381,7 @@
         });
     }
 
-    if ((Model.LevelInt < (int)ViewBag.User.Level && Model.HasActivePenalty || isTempBanned) && ViewBag.Authorized)
+    if ((Model.LevelInt < (int)ViewBag.User.Level && isPermBanned || isTempBanned) && ViewBag.Authorized)
     {
         menuItems.Items.Add(new SideContextMenuItem
         {


### PR DESCRIPTION
Add a temp/mute banner to their profile. (Priority lowered so as not to overwrite temp/ban banners)
Let the user know they cannot target themselves. 
Displays mute expiration on penalty if unmuted early.
Added condition to prevent expiration unmute spam.

```
COMMANDS_DENY_SELF_TARGET = You cannot target yourself

WEBFRONT_PROFILE_MUTE_INFO = Temporarily muted for {{reason}} with {{time}} remaining
WEBFRONT_PROFILE_TEMPMUTE_INFO = Permanently muted for {{reason}}
```