### PR TITLE
Fix conditional logic for parsing ignored events

### DIFF
--- a/Application/EventParsers/BaseEventParser.cs
+++ b/Application/EventParsers/BaseEventParser.cs
@@ -209,7 +209,7 @@ namespace IW4MAdmin.Application.EventParsers
                     // avoid parsing base script event (which has no viable properties) 
                     // and anticheat events as they are manually mapped.
                     // for performance as dynamic "Invoke" is relatively costly due
-                    if (isParseIgnoredEvent)
+                    if (!isParseIgnoredEvent)
                     {
                         createdEvent.ParseArguments();
                     }


### PR DESCRIPTION
The conditional statement in the event parsing logic was incorrect, causing all events to be parsed regardless of the ignore flag. This change corrects the logic to ensure that only non-ignored events are parsed.