### PR TITLE
Utilise Minutes in TempBan for under 1 hour bans.

### DIFF
--- a/SharedLibraryCore/Commands/NativeCommands.cs
+++ b/SharedLibraryCore/Commands/NativeCommands.cs
@@ -229,7 +229,7 @@ namespace SharedLibraryCore.Commands
     /// </summary>
     public class TempBanCommand : Command
     {
-        private static readonly string TempBanRegex = @"^([0-9]{1,5}\w+)\ (.+)";
+        private static readonly string TempBanRegex = @"^([0-9]{1,5}\p{L}+)\ (.+)";
         private readonly ApplicationConfiguration _appConfig;
 
         public TempBanCommand(ApplicationConfiguration appConfig, CommandConfiguration config,

--- a/SharedLibraryCore/Commands/NativeCommands.cs
+++ b/SharedLibraryCore/Commands/NativeCommands.cs
@@ -229,7 +229,7 @@ namespace SharedLibraryCore.Commands
     /// </summary>
     public class TempBanCommand : Command
     {
-        private static readonly string TempBanRegex = @"([0-9]+\w+)\ (.+)";
+        private static readonly string TempBanRegex = @"^([0-9]{1,5}\w+)\ (.+)";
         private readonly ApplicationConfiguration _appConfig;
 
         public TempBanCommand(ApplicationConfiguration appConfig, CommandConfiguration config,

--- a/SharedLibraryCore/Utilities.cs
+++ b/SharedLibraryCore/Utilities.cs
@@ -510,7 +510,7 @@ namespace SharedLibraryCore
 
         public static TimeSpan ParseTimespan(this string input)
         {
-            var expressionMatch = Regex.Match(input, @"^([0-9]{1,5})(\w+)");
+            var expressionMatch = Regex.Match(input, @"^([0-9]{1,5})(\p{L}+)");
 
             if (!expressionMatch.Success) // fallback to default tempban length of 1 hour
             {

--- a/SharedLibraryCore/Utilities.cs
+++ b/SharedLibraryCore/Utilities.cs
@@ -510,7 +510,7 @@ namespace SharedLibraryCore
 
         public static TimeSpan ParseTimespan(this string input)
         {
-            var expressionMatch = Regex.Match(input, @"([0-9]+)(\w+)");
+            var expressionMatch = Regex.Match(input, @"^([0-9]{1,5})(\w+)");
 
             if (!expressionMatch.Success) // fallback to default tempban length of 1 hour
             {

--- a/WebfrontCore/Controllers/ActionController.cs
+++ b/WebfrontCore/Controllers/ActionController.cs
@@ -312,8 +312,8 @@ namespace WebfrontCore.Controllers
             else
             {
                 var durationSpan = _appConfig.BanDurations[duration - 1];
-                var durationValue = durationSpan.TotalHours.ToString(CultureInfo.InvariantCulture) +
-                                    Localization["GLOBAL_TIME_HOURS"][0];
+                var durationValue = durationSpan.TotalMinutes.ToString(CultureInfo.InvariantCulture) +
+                                    Localization["GLOBAL_TIME_MINUTES"][0];
                 command =
                     $"{_appConfig.CommandPrefix}{_tempbanCommandName} @{targetId} {durationValue} {fallthroughReason}";
             }


### PR DESCRIPTION
Previously, configurations with <1hr tempban period presets threw `int.Parse()` floating point issues as it converted it to <1. 

This resolves this by utilising minutes as the smallest time step.