### PR TITLE
Add ResolvedExternalIPAddress to Server API responses

### DIFF
--- a/Application/API/Master/ApiServer.cs
+++ b/Application/API/Master/ApiServer.cs
@@ -24,5 +24,7 @@ namespace IW4MAdmin.Application.API.Master
         public int ClientNum { get; set; }
         [JsonPropertyName("maxclientnum")]
         public int MaxClientNum { get; set; }
+        [JsonPropertyName("resolved_external_ip_address")]
+        public string? ResolvedExternalIPAddress { get; set; }
     }
 }

--- a/Application/Misc/MasterCommunication.cs
+++ b/Application/Misc/MasterCommunication.cs
@@ -149,7 +149,8 @@ namespace IW4MAdmin.Application.Misc
                                 MaxClientNum = s.MaxClients,
                                 Id = s.EndPoint,
                                 Port = (short)s.ListenPort,
-                                IPAddress = s.ListenAddress
+                                IPAddress = s.ListenAddress,
+                                ResolvedExternalIPAddress = s.ResolvedIpEndPoint.Address.IsInternal() ? _manager.ExternalIPAddress : null
                             }).ToList(),
                 WebfrontUrl = _appConfig.WebfrontUrl
             };

--- a/SharedLibraryCore/Dtos/ServerInfo.cs
+++ b/SharedLibraryCore/Dtos/ServerInfo.cs
@@ -25,6 +25,7 @@ namespace SharedLibraryCore.Dtos
         public string IPAddress { get; set; }
         public string ExternalIPAddress { get; set; }
         public bool IsPasswordProtected { get; set; }
+        public string? ResolvedExternalIPAddress { get; set; }
         public string Endpoint => $"{IPAddress}:{Port}";
 
         public double? LobbyZScore

--- a/WebfrontCore/Controllers/API/Server.cs
+++ b/WebfrontCore/Controllers/API/Server.cs
@@ -8,6 +8,7 @@ using SharedLibraryCore.Configuration;
 using SharedLibraryCore.Dtos;
 using SharedLibraryCore.Interfaces;
 using WebfrontCore.Controllers.API.Models;
+using SharedLibraryCore.Extensions;
 
 namespace WebfrontCore.Controllers.API
 {
@@ -39,6 +40,7 @@ namespace WebfrontCore.Controllers.API
                     name = server.GametypeName
                 },
                 Parser = server.RconParser.Name,
+                ResolvedExternalIPAddress = server.ResolvedIpEndPoint.Address.IsInternal() ? Manager.ExternalIPAddress : null
             }));
         }
 
@@ -68,6 +70,7 @@ namespace WebfrontCore.Controllers.API
                     name = foundServer.GametypeName
                 },
                 Parser = foundServer.RconParser.Name,
+                ResolvedExternalIPAddress = foundServer.ResolvedIpEndPoint.Address.IsInternal() ? Manager.ExternalIPAddress : null
             });
         }
 

--- a/WebfrontCore/Controllers/API/Server.cs
+++ b/WebfrontCore/Controllers/API/Server.cs
@@ -8,7 +8,6 @@ using SharedLibraryCore.Configuration;
 using SharedLibraryCore.Dtos;
 using SharedLibraryCore.Interfaces;
 using WebfrontCore.Controllers.API.Models;
-using SharedLibraryCore.Extensions;
 
 namespace WebfrontCore.Controllers.API
 {
@@ -40,7 +39,7 @@ namespace WebfrontCore.Controllers.API
                     name = server.GametypeName
                 },
                 Parser = server.RconParser.Name,
-                ResolvedExternalIPAddress = server.ResolvedIpEndPoint.Address.IsInternal() ? Manager.ExternalIPAddress : null
+                ResolvedExternalIPAddress = server.ResolvedIpEndPoint.Address.IsInternal() ? Manager.ExternalIPAddress : null,
             }));
         }
 


### PR DESCRIPTION
This commit introduces the `ResolvedExternalIPAddress` property to the JSON responses for the server API endpoints located in `WebfrontCore/Controllers/API/Server.cs`.

The `ResolvedExternalIPAddress` property is nullable and contains the IPv4 string value of `Program.Manager.ExternalIPAddress` if the server's `ResolvedIpEndPoint.Address.IsInternal()` is true. Otherwise, it is null.

This enhances the server API by providing external IP information when a server is resolved to an internal IP address.