### PR TITLE
EF Core LINQ Query Fails: DateTime.UtcNow - TimeSpan Cannot Be Transl…

### DIFF
--- a/SharedLibraryCore/Services/PenaltyService.cs
+++ b/SharedLibraryCore/Services/PenaltyService.cs
@@ -198,10 +198,14 @@ namespace SharedLibraryCore.Services
         {
             await using var context = _contextFactory.CreateContext(false);
 
-            var recentlyUsedIps = await context.Aliases.Where(alias => alias.LinkId == linkId)
+            var cutoffDate = DateTime.UtcNow - _appConfig.RecentAliasIpLinkTimeLimit;
+
+            var recentlyUsedIps = await context.Aliases
+                .Where(alias => alias.LinkId == linkId)
                 .Where(alias => alias.IPAddress != null)
-                .Where(alias => alias.DateAdded >= DateTime.UtcNow - _appConfig.RecentAliasIpLinkTimeLimit)
-                .Select(alias => alias.IPAddress).ToListAsync();
+                .Where(alias => alias.DateAdded >= cutoffDate)
+                .Select(alias => alias.IPAddress)
+                .ToListAsync();
 
             if (!recentlyUsedIps.Any())
             {


### PR DESCRIPTION
Summary:
An unhandled exception occurs when running a LINQ query that includes DateTime.UtcNow - TimeSpan as a condition in Where(). EF Core cannot translate this expression into SQL.

> System.InvalidOperationException: The LINQ expression 'DbSet<EFAlias>()
>     .Where(e => e.LinkId == __linkId_0)
>     .Where(e => e.IPAddress != null)
>     .Where(e => e.DateAdded >= DateTime.UtcNow - ___appConfig_RecentAliasIpLinkTimeLimit_1)' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to 'AsEnumerable', 'AsAsyncEnumerable', 'ToList', or 'ToListAsync'. 

Code causing the issue:
```
var recentlyUsedIps = await context.Aliases
    .Where(alias => alias.LinkId == linkId)
    .Where(alias => alias.IPAddress != null)
    .Where(alias => alias.DateAdded >= DateTime.UtcNow - _appConfig.RecentAliasIpLinkTimeLimit)
    .Select(alias => alias.IPAddress)
    .ToListAsync();
```

Fix:

```
var cutoffDate = DateTime.UtcNow - _appConfig.RecentAliasIpLinkTimeLimit;

var recentlyUsedIps = await context.Aliases
    .Where(alias => alias.LinkId == linkId)
    .Where(alias => alias.IPAddress != null)
    .Where(alias => alias.DateAdded >= cutoffDate)
    .Select(alias => alias.IPAddress)
    .ToListAsync();
```

Config Value:
`RecentAliasIpLinkTimeLimit = 7.0:00:00`