### PR TITLE
feat: Support dynamic gameserver configuration

### DIFF
--- a/Application/ApplicationManager.cs
+++ b/Application/ApplicationManager.cs
@@ -70,7 +70,7 @@ namespace IW4MAdmin.Application
         readonly PenaltyService PenaltySvc;
         private readonly IAlertManager _alertManager;
         private readonly ConfigurationWatcher _watcher;
-        public IConfigurationHandler<ApplicationConfiguration> ConfigHandler;
+        private readonly IConfigurationHandlerV2<ApplicationConfiguration> _appConfigHandler;
         readonly IPageList PageList;
         private readonly TimeSpan _throttleTimeout = new TimeSpan(0, 1, 0);
         private CancellationTokenSource _isRunningTokenSource;
@@ -92,13 +92,15 @@ namespace IW4MAdmin.Application
 
         public ApplicationManager(ILogger<ApplicationManager> logger, IMiddlewareActionHandler actionHandler, IEnumerable<IManagerCommand> commands,
             ITranslationLookup translationLookup, IConfigurationHandler<CommandConfiguration> commandConfiguration,
-            IConfigurationHandler<ApplicationConfiguration> appConfigHandler, IGameServerInstanceFactory serverInstanceFactory,
+            IConfigurationHandlerV2<ApplicationConfiguration> appConfigHandlerV2, IGameServerInstanceFactory serverInstanceFactory,
             IEnumerable<IPlugin> plugins, IParserRegexFactory parserRegexFactory, IEnumerable<IRegisterEvent> customParserEvents,
             ICoreEventHandler coreEventHandler, IScriptCommandFactory scriptCommandFactory, IDatabaseContextFactory contextFactory,
             IMetaRegistration metaRegistration, IScriptPluginServiceResolver scriptPluginServiceResolver, ClientService clientService, IServiceProvider serviceProvider,
             ChangeHistoryService changeHistoryService, ApplicationConfiguration appConfig, PenaltyService penaltyService, IAlertManager alertManager, IInteractionRegistration interactionRegistration, IEnumerable<IPluginV2> v2PLugins,
             ConfigurationWatcher watcher)
         {
+            _appConfigHandler = appConfigHandlerV2;
+            _appConfigHandler.Updated += OnConfigurationUpdated;
             MiddlewareActionHandler = actionHandler;
             _servers = new ConcurrentBag<Server>();
             MessageTokens = new List<MessageToken>();
@@ -106,7 +108,6 @@ namespace IW4MAdmin.Application
             PenaltySvc = penaltyService;
             _alertManager = alertManager;
             _watcher = watcher;
-            ConfigHandler = appConfigHandler;
             StartTime = DateTime.UtcNow;
             PageList = new PageList();
             AdditionalEventParsers = new List<IEventParser> { new BaseEventParser(parserRegexFactory, logger, appConfig, serviceProvider.GetRequiredService<IGameScriptEventFactory>()) };
@@ -258,22 +259,22 @@ namespace IW4MAdmin.Application
             const int delayScalar = 50; // Task.Delay is inconsistent enough there's no reason to try to prevent collisions
             var timeout = TimeSpan.FromMinutes(2);
 
-            while (!_isRunningTokenSource.IsCancellationRequested)
+            while (!server.CancellationToken.IsCancellationRequested)
             {
                 try
                 {
                     var delayFactor = Math.Min(_appConfig.RConPollRate, delayScalar * index);
-                    await Task.Delay(delayFactor, _isRunningTokenSource.Token);
+                    await Task.Delay(delayFactor, server.CancellationToken);
 
                     using var timeoutTokenSource = new CancellationTokenSource();
                     timeoutTokenSource.CancelAfter(timeout);
                     using var linkedTokenSource =
                         CancellationTokenSource.CreateLinkedTokenSource(timeoutTokenSource.Token,
-                            _isRunningTokenSource.Token);
+                            server.CancellationToken);
                     await server.ProcessUpdatesAsync(linkedTokenSource.Token);
 
                     await Task.Delay(Math.Max(1000, _appConfig.RConPollRate - delayFactor),
-                        _isRunningTokenSource.Token);
+                        server.CancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -293,7 +294,7 @@ namespace IW4MAdmin.Application
             }
             
             // run the final updates to clean up server
-            await server.ProcessUpdatesAsync(_isRunningTokenSource.Token);
+            await server.ProcessUpdatesAsync(server.CancellationToken);
         }
 
         public async Task Init()
@@ -369,7 +370,7 @@ namespace IW4MAdmin.Application
 
                 //if (newConfig.Servers == null)
                 {
-                    ConfigHandler.Set(_appConfig);
+                await _appConfigHandler.Set(_appConfig);
                     _appConfig.Servers = new ServerConfiguration[1];
 
                     do
@@ -388,7 +389,7 @@ namespace IW4MAdmin.Application
                         _appConfig.Servers = _appConfig.Servers.Where(_servers => _servers != null).Append((ServerConfiguration)serverConfig.Generate()).ToArray();
                     } while (Utilities.PromptBool(_translationLookup["SETUP_SERVER_SAVE"]));
 
-                    await ConfigHandler.Save();
+                await _appConfigHandler.Set(_appConfig);
                 }
             }
 
@@ -424,7 +425,7 @@ namespace IW4MAdmin.Application
                     throw new ConfigurationException("Could not validate configuration")
                     {
                         Errors = validationResult.Errors.Select(_error => _error.ErrorMessage).ToArray(),
-                        ConfigurationFileName = ConfigHandler.FileName
+                        ConfigurationFileName = "IW4MAdminSettings.json"
                     };
                 }
 
@@ -449,8 +450,7 @@ namespace IW4MAdmin.Application
                     }
                 }
                 
-                ConfigHandler.Set(_appConfig);
-                await ConfigHandler.Save();
+                await _appConfigHandler.Set(_appConfig);
             }
 
             if (_appConfig.Servers.Length == 0)
@@ -542,7 +542,7 @@ namespace IW4MAdmin.Application
 
         private async Task InitializeServers()
         {
-            var config = ConfigHandler.Configuration();
+            var config = _appConfig;
             int successServers = 0;
             Exception lastException = null;
 
@@ -688,9 +688,25 @@ namespace IW4MAdmin.Application
             return PenaltySvc;
         }
 
-        public IConfigurationHandler<ApplicationConfiguration> GetApplicationSettings()
+        private async void OnConfigurationUpdated(ApplicationConfiguration newConfig)
         {
-            return ConfigHandler;
+            var newServers = newConfig.Servers.ToList();
+            var currentServers = _servers.ToList();
+
+            var serversToAdd = newServers.Where(s => currentServers.All(cs => cs.Id != $"{s.IPAddress}:{s.Port}")).ToList();
+            var serversToRemove = currentServers.Where(cs => newServers.All(s => cs.Id != $"{s.IPAddress}:{s.Port}")).ToList();
+
+            _logger.LogDebug("Detected configuration file change. Adding {AddCount} servers and removing {RemoveCount} servers", serversToAdd.Count, serversToRemove.Count);
+
+            foreach (var serverConfig in serversToAdd)
+            {
+                await AddServer(serverConfig);
+            }
+
+            foreach (var server in serversToRemove)
+            {
+                await RemoveServer(server.Id);
+            }
         }
 
         public void AddEvent(GameEvent gameEvent)
@@ -718,7 +734,7 @@ namespace IW4MAdmin.Application
 
         public IEventParser GenerateDynamicEventParser(string name)
         {
-            return new DynamicEventParser(_parserRegexFactory, _logger, ConfigHandler.Configuration(), _serviceProvider.GetRequiredService<IGameScriptEventFactory>())
+            return new DynamicEventParser(_parserRegexFactory, _logger, _appConfig, _serviceProvider.GetRequiredService<IGameScriptEventFactory>())
             {
                 Name = name
             };
@@ -897,6 +913,63 @@ namespace IW4MAdmin.Application
                         receiveEvent.Client.CurrentServer.AsConsoleClient(), true);
                 }
             }
+        }
+
+        public async Task AddServer(ServerConfiguration serverConfig)
+        {
+            var serverInstance = _serverInstanceFactory.CreateServer(serverConfig, this) as IW4MServer;
+
+            try
+            {
+                using (LogContext.PushProperty("Server", serverInstance!.ToString()))
+                {
+                    _logger.LogInformation("Beginning server communication initialization");
+                    await serverInstance.Initialize();
+
+                    _servers.Add(serverInstance);
+                    _ = ProcessUpdateHandler(serverInstance, _servers.Count);
+                    Console.WriteLine(Utilities.CurrentLocalization.LocalizationIndex["MANAGER_MONITORING_TEXT"].FormatExt(serverInstance.Hostname.StripColors()));
+                    _logger.LogInformation("Finishing initialization and now monitoring [{Server}]", serverInstance.Hostname);
+                }
+
+                QueueEvent(new MonitorStartEvent
+                {
+                    Server = serverInstance,
+                    Source = this
+                });
+            }
+            catch (ServerException e)
+            {
+                Console.WriteLine(Utilities.CurrentLocalization.LocalizationIndex["SERVER_ERROR_UNFIXABLE"].FormatExt($"[{serverConfig.IPAddress}:{serverConfig.Port}]"));
+                using (LogContext.PushProperty("Server", $"{serverConfig.IPAddress}:{serverConfig.Port}"))
+                {
+                    _logger.LogError(e, "Unexpected exception occurred during initialization");
+                }
+            }
+        }
+
+        public async Task RemoveServer(string serverEndpoint)
+        {
+            var server = _servers.FirstOrDefault(s => s.Id == serverEndpoint);
+
+            if (server == null)
+            {
+                _logger.LogWarning("Could not find server with endpoint {Endpoint} to remove", serverEndpoint);
+                return;
+            }
+
+            server.CancellationTokenSource.Cancel();
+            // give the server a moment to cancel gracefully
+            await Task.Delay(500);
+            _servers.TryTake(out server);
+
+            QueueEvent(new MonitorStopEvent
+            {
+                Server = server,
+                Source = this
+            });
+
+            _logger.LogInformation("Stopped monitoring server {Server}", server.Id);
         }
     }
 }

--- a/Application/Factories/GameServerInstanceFactory.cs
+++ b/Application/Factories/GameServerInstanceFactory.cs
@@ -40,6 +40,7 @@ namespace IW4MAdmin.Application.Factories
         public Server CreateServer(ServerConfiguration config, IManager manager)
         {
             return new IW4MServer(config,
+                _serviceProvider.GetRequiredService<ApplicationConfiguration>(),
                 _serviceProvider.GetRequiredService<CommandConfiguration>(), _translationLookup, _metaService,
                 _serviceProvider, _serviceProvider.GetRequiredService<IClientNoticeMessageFormatter>(),
                 _serviceProvider.GetRequiredService<ILookupCache<EFServer>>());

--- a/Application/IW4MServer.cs
+++ b/Application/IW4MServer.cs
@@ -58,6 +58,7 @@ namespace IW4MAdmin
 
         public IW4MServer(
             ServerConfiguration serverConfiguration,
+            ApplicationConfiguration appConfig,
             CommandConfiguration commandConfiguration,
             ITranslationLookup lookup,
             IMetaServiceV2 metaService, 
@@ -68,6 +69,7 @@ namespace IW4MAdmin
             serviceProvider.GetRequiredService<SharedLibraryCore.Interfaces.ILogger>(), 
 #pragma warning restore CS0612
             serverConfiguration,
+            appConfig,
             serviceProvider.GetRequiredService<IManager>(), 
             serviceProvider.GetRequiredService<IRConConnectionFactory>(),
             serviceProvider.GetRequiredService<IGameLogReaderFactory>(), serviceProvider)
@@ -1777,7 +1779,7 @@ namespace IW4MAdmin
             });
         }
 
-        public override void InitializeTokens()
+        public override void InitializeTokens(ApplicationConfiguration appConfig)
         {
             Manager.GetMessageTokens().Add(new MessageToken("TOTALPLAYERS", (Server s) => Task.Run(async () => (await Manager.GetClientService().GetTotalClientsAsync()).ToString())));
             Manager.GetMessageTokens().Add(new MessageToken("VERSION", (Server s) => Task.FromResult(Application.Program.Version.ToString())));

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -222,8 +222,9 @@ namespace IW4MAdmin.Application
             var masterCommunicator = serviceProvider.GetRequiredService<IMasterCommunication>();
             var webfrontLifetime = serviceProvider.GetRequiredService<IHostApplicationLifetime>();
             using var onWebfrontErrored = new ManualResetEventSlim();
+            var appConfig = serviceProvider.GetRequiredService<ApplicationConfiguration>();
             
-            var webfrontTask = _serverManager.GetApplicationSettings().Configuration().EnableWebFront
+            var webfrontTask = appConfig.EnableWebFront
                 ? WebfrontCore.Program.GetWebHostTask(_serverManager.CancellationToken).ContinueWith(continuation =>
                 {
                     if (!continuation.IsFaulted)
@@ -436,17 +437,17 @@ namespace IW4MAdmin.Application
                 .AddConfiguration<StatsConfiguration>("StatsPluginSettings");
             
             // for legacy purposes. update at some point
-            var appConfigHandler = new BaseConfigurationHandler<ApplicationConfiguration>("IW4MAdminSettings");
-            appConfigHandler.BuildAsync().GetAwaiter().GetResult();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var appConfigHandler = serviceProvider.GetRequiredService<IConfigurationHandlerV2<ApplicationConfiguration>>();
+            var appConfig = appConfigHandler.Get("IW4MAdminSettings").Result;
+
             var commandConfigHandler = new BaseConfigurationHandler<CommandConfiguration>("CommandConfiguration");
             commandConfigHandler.BuildAsync().GetAwaiter().GetResult();
 
-            if (appConfigHandler.Configuration()?.MasterUrl == new Uri("http://api.raidmax.org:5000"))
+            if (appConfig?.MasterUrl == new Uri("http://api.raidmax.org:5000"))
             {
-                appConfigHandler.Configuration().MasterUrl = new ApplicationConfiguration().MasterUrl;
+                appConfig.MasterUrl = new ApplicationConfiguration().MasterUrl;
             }
-
-            var appConfig = appConfigHandler.Configuration();
             var masterUri = Utilities.IsDevelopment
                 ? new Uri("http://127.0.0.1:8080")
                 : appConfig?.MasterUrl ?? new ApplicationConfiguration().MasterUrl;
@@ -461,8 +462,7 @@ namespace IW4MAdmin.Application
             if (appConfig == null)
             {
                 appConfig = (ApplicationConfiguration) new ApplicationConfiguration().Generate();
-                appConfigHandler.Set(appConfig);
-                appConfigHandler.Save().GetAwaiter().GetResult();
+                appConfigHandler.Set(appConfig).GetAwaiter().GetResult();
             }
 
             // register override level names
@@ -474,7 +474,7 @@ namespace IW4MAdmin.Application
             // build the dependency list
             serviceCollection
                 .AddBaseLogger(appConfig)
-                .AddSingleton((IConfigurationHandler<ApplicationConfiguration>) appConfigHandler)
+                .AddSingleton<IConfigurationHandlerV2<ApplicationConfiguration>>(appConfigHandler)
                 .AddSingleton<IConfigurationHandler<CommandConfiguration>>(commandConfigHandler)
                 .AddSingleton(serviceProvider =>
                     serviceProvider.GetRequiredService<IConfigurationHandler<CommandConfiguration>>()

--- a/SharedLibraryCore/Interfaces/IManager.cs
+++ b/SharedLibraryCore/Interfaces/IManager.cs
@@ -46,7 +46,6 @@ namespace SharedLibraryCore.Interfaces
         IList<MessageToken> GetMessageTokens();
         IList<EFClient> GetActiveClients();
         EFClient FindActiveClient(EFClient client);
-        IConfigurationHandler<ApplicationConfiguration> GetApplicationSettings();
         ClientService GetClientService();
         PenaltyService GetPenaltyService();
 
@@ -113,5 +112,19 @@ namespace SharedLibraryCore.Interfaces
 
         IAlertManager AlertManager { get; }
         IInteractionRegistration InteractionRegistration { get; }
+
+        /// <summary>
+        ///  Adds a new server to the manager
+        /// </summary>
+        /// <param name="serverConfig">configuration of the server to add</param>
+        /// <returns></returns>
+        Task AddServer(ServerConfiguration serverConfig);
+
+        /// <summary>
+        /// Removes a server from the manager
+        /// </summary>
+        /// <param name="serverEndpoint">endpoint of the server to remove</param>
+        /// <returns></returns>
+        Task RemoveServer(string serverEndpoint);
     }
 }

--- a/SharedLibraryCore/Server.cs
+++ b/SharedLibraryCore/Server.cs
@@ -62,7 +62,7 @@ namespace SharedLibraryCore
 #pragma warning disable CS0612
         public Server(ILogger<Server> logger, Interfaces.ILogger deprecatedLogger,
 #pragma warning restore CS0612
-            ServerConfiguration config, IManager mgr, IRConConnectionFactory rconConnectionFactory,
+            ServerConfiguration config, ApplicationConfiguration appConfig, IManager mgr, IRConConnectionFactory rconConnectionFactory,
             IGameLogReaderFactory gameLogReaderFactory, IServiceProvider serviceProvider)
         {
             Password = config.Password;
@@ -79,14 +79,15 @@ namespace SharedLibraryCore
             ClientHistory = new ClientHistoryInfo();
             ChatHistory = new List<ChatInfo>();
             NextMessage = 0;
-            CustomSayEnabled = Manager.GetApplicationSettings().Configuration().EnableCustomSayName;
-            CustomSayName = Manager.GetApplicationSettings().Configuration().CustomSayName;
+            CustomSayEnabled = appConfig.EnableCustomSayName;
+            CustomSayName = appConfig.CustomSayName;
             this.gameLogReaderFactory = gameLogReaderFactory;
             RConConnectionFactory = rconConnectionFactory;
             ServerLogger = logger;
             DefaultSettings = serviceProvider.GetRequiredService<DefaultSettings>();
-            InitializeTokens();
-            InitializeAutoMessages();
+            CancellationTokenSource = new CancellationTokenSource();
+            InitializeTokens(appConfig);
+            InitializeAutoMessages(appConfig);
         }
 
         public long EndPoint => IPAddress.TryParse(ListenAddress, out _)
@@ -95,6 +96,8 @@ namespace SharedLibraryCore
 
         public abstract long LegacyDatabaseId { get; }
         public string Id => $"{ListenAddress}:{ListenPort}";
+        public CancellationTokenSource CancellationTokenSource { get; }
+        public CancellationToken CancellationToken => CancellationTokenSource.Token;
 
         // Objects
         public IManager Manager { get; protected set; }
@@ -399,12 +402,12 @@ namespace SharedLibraryCore
         /// <summary>
         ///     Initalize the macro variables
         /// </summary>
-        public abstract void InitializeTokens();
+        public abstract void InitializeTokens(ApplicationConfiguration appConfig);
 
         /// <summary>
         ///     Initialize the messages to be broadcasted
         /// </summary>
-        protected void InitializeAutoMessages()
+        protected void InitializeAutoMessages(ApplicationConfiguration appConfig)
         {
             BroadcastMessages = new List<string>();
 
@@ -413,7 +416,7 @@ namespace SharedLibraryCore
                 BroadcastMessages.AddRange(ServerConfig.AutoMessages);
             }
 
-            BroadcastMessages.AddRange(Manager.GetApplicationSettings().Configuration().AutoMessages);
+            BroadcastMessages.AddRange(appConfig.AutoMessages);
         }
 
         public override string ToString()

--- a/WebfrontCore/Startup.cs
+++ b/WebfrontCore/Startup.cs
@@ -133,10 +133,11 @@ namespace WebfrontCore
                 app.UseExceptionHandler("/Home/Error");
             }
 
-            if (Program.Manager.GetApplicationSettings().Configuration().EnableWebfrontConnectionWhitelist)
+            var appConfig = serviceProvider.GetRequiredService<ApplicationConfiguration>();
+            if (appConfig.EnableWebfrontConnectionWhitelist)
             {
                 app.UseMiddleware<IPWhitelist>(serviceProvider.GetService<ILogger<IPWhitelist>>(),
-                    serviceProvider.GetRequiredService<ApplicationConfiguration>().WebfrontConnectionWhitelist);
+                    appConfig.WebfrontConnectionWhitelist);
             }
 
             app.UseStaticFiles();


### PR DESCRIPTION
Draft for building. Not legitimate PR

This change introduces support for dynamically adding and removing game servers from the managed set without restarting IW4MAdmin.

The `ApplicationManager` now listens for changes to the `IW4MAdminSettings.json` file. When the file is updated, the manager will:
- Add any new servers present in the configuration.
- Remove any servers that are no longer in the configuration.

This is achieved by:
- Introducing `AddServer` and `RemoveServer` methods to the `IManager` and `ApplicationManager`.
- Adding a `CancellationTokenSource` to each `Server` instance to allow for individual server shutdown.
- Refactoring `ApplicationManager` to use `IConfigurationHandlerV2` which supports dynamic updates.
- Updating the dependency injection configuration to use the new handler.