### PR TITLE
Added zom -> Zombies fix for T4ZM

### DIFF
--- a/Application/DefaultSettings.json
+++ b/Application/DefaultSettings.json
@@ -186,10 +186,14 @@
           "Name": "twar",
           "Alias": "War"
         },
-	{
+	    {
           "Name": "cmp",
           "Alias": "Zombies"
-        }	      
+        },
+		{
+          "Name": "zom",
+          "Alias": "Zombies"
+        }	
       ]
     },
     {


### PR DESCRIPTION
Both cmp and zom are now handled as the "Zombies" gametype.

It was observed that after the recent Pluto T4 refactor, some servers began reporting the gametype as both cmp and zom. 

While im unsure if zom is related to the refactor or not, but this change ensures both are correctly identified.