### PR TITLE
Gracefully handle plugins that target a newer IW4MAdmin API

### DIFF
--- a/Application/ApplicationManager.cs
+++ b/Application/ApplicationManager.cs
@@ -378,7 +378,7 @@ namespace IW4MAdmin.Application
 
                 catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
                 {
-                    PluginApiCompatibility.NotifyNewerApiRequired(plugin.GetType().Assembly, _logger, plugin.Name);
+                    PluginApiCompatibility.NotifyNewerApiRequired(plugin.GetType().Assembly, plugin.Name);
                 }
 
                 catch (Exception ex)

--- a/Application/ApplicationManager.cs
+++ b/Application/ApplicationManager.cs
@@ -376,6 +376,11 @@ namespace IW4MAdmin.Application
                     }
                 }
 
+                catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
+                {
+                    PluginApiCompatibility.NotifyNewerApiRequired(plugin.GetType().Assembly, _logger, plugin.Name);
+                }
+
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, $"{_translationLookup["SERVER_ERROR_PLUGIN"]} {plugin.Name}");

--- a/Application/IW4MServer.cs
+++ b/Application/IW4MServer.cs
@@ -301,7 +301,7 @@ namespace IW4MAdmin
                 catch (Exception e) when (PluginApiCompatibility.IsMissingApiException(e))
                 {
                     PluginApiCompatibility.NotifyNewerApiRequired(
-                        PluginApiCompatibility.TryGetOffendingAssembly(e), ServerLogger);
+                        PluginApiCompatibility.TryGetOffendingAssembly(e));
                     if (E.Origin != null && E.Type == GameEvent.EventType.Command)
                     {
                         E.Origin.Tell(_translationLookup["SERVER_ERROR_COMMAND_INGAME"]);

--- a/Application/IW4MServer.cs
+++ b/Application/IW4MServer.cs
@@ -298,6 +298,16 @@ namespace IW4MAdmin
                     await Task.WhenAll(pluginTasks);
                 }
 
+                catch (Exception e) when (PluginApiCompatibility.IsMissingApiException(e))
+                {
+                    PluginApiCompatibility.NotifyNewerApiRequired(
+                        PluginApiCompatibility.TryGetOffendingAssembly(e), ServerLogger);
+                    if (E.Origin != null && E.Type == GameEvent.EventType.Command)
+                    {
+                        E.Origin.Tell(_translationLookup["SERVER_ERROR_COMMAND_INGAME"]);
+                    }
+                }
+
                 catch (Exception e)
                 {
                     ServerLogger.LogError(e, "Unexpected exception occurred processing event");

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -106,6 +106,8 @@ namespace IW4MAdmin.Application
 
             Console.CancelKeyPress += OnCancelKey;
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
             Console.WriteLine("=====================================================");
             Console.WriteLine(" IW4MAdmin");
@@ -175,6 +177,40 @@ namespace IW4MAdmin.Application
         {
             Utilities.DefaultLogger.LogDebug("ProcessExit event received, performing synchronous shutdown");
             PerformShutdownAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Last-resort handler for an exception that escaped to a background/thread-pool thread —
+        /// typically a plugin <c>async void</c> handler or an unguarded fire-and-forget. The runtime
+        /// terminates the process after this returns (<see cref="UnhandledExceptionEventArgs.IsTerminating"/>
+        /// is set and there is no API to mark it handled), so we cannot recover. We can, however,
+        /// persist it to the IW4MAdmin log instead of losing it to stdout/stderr — which is gone the
+        /// moment a container is recreated. The Serilog file sink writes synchronously, so the entry
+        /// reaches disk before teardown.
+        /// </summary>
+        private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            var exception = e.ExceptionObject as Exception;
+            Utilities.DefaultLogger?.LogCritical(exception,
+                "Unhandled exception escaped to the runtime (terminating: {IsTerminating}). This is almost " +
+                "always a plugin throwing on a background thread, which IW4MAdmin cannot catch or recover from",
+                e.IsTerminating);
+
+            // belt-and-braces: the process is dying; make sure it also lands on stderr in case the
+            // logger was not yet initialised (very early startup)
+            Console.Error.WriteLine($"[FATAL] Unhandled exception: {exception}");
+        }
+
+        /// <summary>
+        /// Handler for a faulted <see cref="Task"/> that was never awaited/observed. Since .NET Core
+        /// these no longer terminate the process, so without this they vanish silently — usually a
+        /// plugin fire-and-forget bug. We log it and mark it observed so the behaviour stays explicit.
+        /// </summary>
+        private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Utilities.DefaultLogger?.LogError(e.Exception,
+                "Unobserved task exception (likely a plugin fire-and-forget that faulted); marking observed");
+            e.SetObserved();
         }
 
         /// <summary>
@@ -449,8 +485,7 @@ namespace IW4MAdmin.Application
                         // identify by assembly (the recognizable plugin/DLL name) rather than the
                         // bare class name, which is usually just "Plugin"
                         var pluginName = localPluginType.Assembly.GetName().Name;
-                        PluginApiCompatibility.NotifyNewerApiRequired(localPluginType.Assembly, defaultLogger,
-                            pluginName);
+                        PluginApiCompatibility.NotifyNewerApiRequired(localPluginType.Assembly, pluginName);
                         return new UnavailablePlugin(pluginName);
                     }
                 });
@@ -462,7 +497,7 @@ namespace IW4MAdmin.Application
                 }
                 catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
                 {
-                    PluginApiCompatibility.NotifyNewerApiRequired(pluginType.Assembly, defaultLogger);
+                    PluginApiCompatibility.NotifyNewerApiRequired(pluginType.Assembly);
                 }
                 catch (Exception ex)
                 {
@@ -501,8 +536,7 @@ namespace IW4MAdmin.Application
             foreach (var assemblyType in typeof(Program).Assembly.GetTypes()
                          .Where(asmType => typeof(IRegisterEvent).IsAssignableFrom(asmType))
                          .Union(plugins.Select(pluginType => pluginType.Assembly).Distinct()
-                             .SelectMany(asm => PluginApiCompatibility.GetLoadableTypes(asm, defaultLogger))
-                             .Distinct()
+                             .SelectMany(PluginApiCompatibility.GetLoadableTypes)
                              .Where(asmType => typeof(IRegisterEvent).IsAssignableFrom(asmType))))
             {
                 var instance = Activator.CreateInstance(assemblyType) as IRegisterEvent;

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -431,7 +431,29 @@ namespace IW4MAdmin.Application
 
                 defaultLogger.LogDebug("Registering plugin type {Name}", pluginType.FullName);
 
-                serviceCollection.AddSingleton(!isV2 ? typeof(IPlugin) : typeof(IPluginV2), pluginType);
+                // Instantiate through a guarded factory: a plugin compiled against newer
+                // API can load fine here yet throw at construction (e.g. a ctor body call
+                // or a member typed with a missing type, neither of which fails at type
+                // load). Because IEnumerable<IPluginV2> is resolved in bulk, one such throw
+                // would otherwise take down the whole host. Soft-fail to an inert
+                // placeholder and tell the user once instead.
+                var localPluginType = pluginType;
+                serviceCollection.AddSingleton(!isV2 ? typeof(IPlugin) : typeof(IPluginV2), sp =>
+                {
+                    try
+                    {
+                        return ActivatorUtilities.CreateInstance(sp, localPluginType);
+                    }
+                    catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
+                    {
+                        // identify by assembly (the recognizable plugin/DLL name) rather than the
+                        // bare class name, which is usually just "Plugin"
+                        var pluginName = localPluginType.Assembly.GetName().Name;
+                        PluginApiCompatibility.NotifyNewerApiRequired(localPluginType.Assembly, defaultLogger,
+                            pluginName);
+                        return new UnavailablePlugin(pluginName);
+                    }
+                });
 
                 try
                 {

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -436,7 +436,11 @@ namespace IW4MAdmin.Application
                 try
                 {
                     var registrationMethod = pluginType.GetMethod(nameof(IPluginV2.RegisterDependencies));
-                    registrationMethod?.Invoke(null, new object[] { serviceCollection });
+                    registrationMethod?.Invoke(null, [serviceCollection]);
+                }
+                catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
+                {
+                    PluginApiCompatibility.NotifyNewerApiRequired(pluginType.Assembly, defaultLogger);
                 }
                 catch (Exception ex)
                 {
@@ -474,7 +478,8 @@ namespace IW4MAdmin.Application
             // register any eventable types
             foreach (var assemblyType in typeof(Program).Assembly.GetTypes()
                          .Where(asmType => typeof(IRegisterEvent).IsAssignableFrom(asmType))
-                         .Union(plugins.SelectMany(asm => asm.Assembly.GetTypes())
+                         .Union(plugins.Select(pluginType => pluginType.Assembly).Distinct()
+                             .SelectMany(asm => PluginApiCompatibility.GetLoadableTypes(asm, defaultLogger))
                              .Distinct()
                              .Where(asmType => typeof(IRegisterEvent).IsAssignableFrom(asmType))))
             {

--- a/Application/Plugin/PluginImporter.cs
+++ b/Application/Plugin/PluginImporter.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
 using SharedLibraryCore;
 using SharedLibraryCore.Configuration;
+using SharedLibraryCore.Helpers;
 using SharedLibraryCore.Interfaces;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -128,17 +129,8 @@ namespace IW4MAdmin.Application.Plugin
 
             var eligibleAssemblyTypes = assemblies.Concat(AppDomain.CurrentDomain.GetAssemblies()
                     .Where(asm => !new[] { "IW4MAdmin", "SharedLibraryCore", "Stats" }.Contains(asm.GetName().Name)))
-                .SelectMany(asm =>
-                {
-                    try
-                    {
-                        return asm.GetTypes();
-                    }
-                    catch
-                    {
-                        return [];
-                    }
-                }).Where(type =>
+                .SelectMany(asm => PluginApiCompatibility.GetLoadableTypes(asm, _logger))
+                .Where(type =>
                     FilterTypes.Any(filterType => type.GetInterface(filterType.Name, false) != null) ||
                     (type.IsClass && FilterTypes.Contains(type.BaseType)));
 

--- a/Application/Plugin/PluginImporter.cs
+++ b/Application/Plugin/PluginImporter.cs
@@ -129,6 +129,10 @@ namespace IW4MAdmin.Application.Plugin
 
             var eligibleAssemblyTypes = assemblies.Concat(AppDomain.CurrentDomain.GetAssemblies()
                     .Where(asm => !new[] { "IW4MAdmin", "SharedLibraryCore", "Stats" }.Contains(asm.GetName().Name)))
+                // a plugin loaded from the Plugins dir is also present in the AppDomain, so the
+                // concat above lists it twice; dedupe by identity so each plugin type is only
+                // discovered (and later registered/instantiated) once
+                .DistinctBy(asm => asm.FullName)
                 .SelectMany(asm => PluginApiCompatibility.GetLoadableTypes(asm, _logger))
                 .Where(type =>
                     FilterTypes.Any(filterType => type.GetInterface(filterType.Name, false) != null) ||

--- a/Application/Plugin/PluginImporter.cs
+++ b/Application/Plugin/PluginImporter.cs
@@ -133,7 +133,7 @@ namespace IW4MAdmin.Application.Plugin
                 // concat above lists it twice; dedupe by identity so each plugin type is only
                 // discovered (and later registered/instantiated) once
                 .DistinctBy(asm => asm.FullName)
-                .SelectMany(asm => PluginApiCompatibility.GetLoadableTypes(asm, _logger))
+                .SelectMany(PluginApiCompatibility.GetLoadableTypes)
                 .Where(type =>
                     FilterTypes.Any(filterType => type.GetInterface(filterType.Name, false) != null) ||
                     (type.IsClass && FilterTypes.Contains(type.BaseType)));

--- a/SharedLibraryCore/Events/EventExtensions.cs
+++ b/SharedLibraryCore/Events/EventExtensions.cs
@@ -41,7 +41,7 @@ public static class EventExtensions
         {
             // a plugin handler called API that doesn't exist in this (older) IW4MAdmin; soft-fail
             // and tell the user once instead of silently doing nothing
-            PluginApiCompatibility.NotifyNewerApiRequired(handler.Method.DeclaringType?.Assembly, logger: null);
+            PluginApiCompatibility.NotifyNewerApiRequired(handler.Method.DeclaringType?.Assembly);
         }
         catch (Exception)
         {

--- a/SharedLibraryCore/Events/EventExtensions.cs
+++ b/SharedLibraryCore/Events/EventExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using SharedLibraryCore.Helpers;
 
 namespace SharedLibraryCore.Events;
 
@@ -35,6 +36,12 @@ public static class EventExtensions
         try
         {
             await handler(eventArgType, tokenSource.Token);
+        }
+        catch (Exception ex) when (PluginApiCompatibility.IsMissingApiException(ex))
+        {
+            // a plugin handler called API that doesn't exist in this (older) IW4MAdmin; soft-fail
+            // and tell the user once instead of silently doing nothing
+            PluginApiCompatibility.NotifyNewerApiRequired(handler.Method.DeclaringType?.Assembly, logger: null);
         }
         catch (Exception)
         {

--- a/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
+++ b/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
@@ -121,8 +121,10 @@ public static class PluginApiCompatibility
         }
 
         var pluginName = displayName ?? assembly?.GetName().Name ?? "A plugin";
+
+        // user-facing console notice is localized; the log line below stays hardcoded English
         Console.WriteLine(
-            $"[Plugin] {pluginName} uses newer/unavailable IW4MAdmin API. Please update IW4MAdmin to load it.");
+            $"[Plugin] {Utilities.CurrentLocalization.LocalizationIndex["PLUGIN_IMPORTER_NEWER_API"].FormatExt(pluginName)}");
         Utilities.DefaultLogger?.LogWarning(
             "{Plugin} could not be fully loaded because it targets a newer IW4MAdmin API than this instance provides",
             pluginName);

--- a/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
+++ b/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
@@ -53,7 +53,7 @@ public static class PluginApiCompatibility
     /// Types whose signatures resolve are returned and still load; types that need unavailable API
     /// are dropped and a single friendly notice is surfaced per assembly.
     /// </summary>
-    public static IEnumerable<Type> GetLoadableTypes(Assembly assembly, ILogger logger)
+    public static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
     {
         try
         {
@@ -64,7 +64,7 @@ public static class PluginApiCompatibility
             if (ex.LoaderExceptions.Any(loaderException =>
                     loaderException is not null && IsMissingApiCore(loaderException)))
             {
-                NotifyNewerApiRequired(assembly, logger);
+                NotifyNewerApiRequired(assembly);
             }
 
             // surface the types that did resolve so plugins that don't actually use the missing
@@ -73,7 +73,7 @@ public static class PluginApiCompatibility
         }
         catch (Exception ex) when (IsMissingApiException(ex))
         {
-            NotifyNewerApiRequired(assembly, logger);
+            NotifyNewerApiRequired(assembly);
             return [];
         }
     }
@@ -101,8 +101,12 @@ public static class PluginApiCompatibility
     /// <summary>
     /// emits a user-facing notice (console + log) that a plugin could not be loaded/run because it
     /// targets a newer IW4MAdmin API. Reports at most once per plugin for the life of the process.
+    /// Logging goes through <see cref="Utilities.DefaultLogger"/> — the ambient logger IW4MAdmin
+    /// provides for code not created by dependency injection. That is deliberate: the call sites are
+    /// the static event dispatch (<c>EventExtensions</c>) and registration-time plugin discovery,
+    /// neither of which has a DI scope to inject an <c>ILogger</c> from.
     /// </summary>
-    public static void NotifyNewerApiRequired(Assembly assembly, ILogger logger, string displayName = null)
+    public static void NotifyNewerApiRequired(Assembly assembly, string displayName = null)
     {
         var key = assembly?.FullName ?? displayName;
         if (key is not null)
@@ -119,7 +123,7 @@ public static class PluginApiCompatibility
         var pluginName = displayName ?? assembly?.GetName().Name ?? "A plugin";
         Console.WriteLine(
             $"[Plugin] {pluginName} uses newer/unavailable IW4MAdmin API. Please update IW4MAdmin to load it.");
-        logger?.LogWarning(
+        Utilities.DefaultLogger?.LogWarning(
             "{Plugin} could not be fully loaded because it targets a newer IW4MAdmin API than this instance provides",
             pluginName);
     }

--- a/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
+++ b/SharedLibraryCore/Helpers/PluginApiCompatibility.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace SharedLibraryCore.Helpers;
+
+/// <summary>
+/// helpers for tolerating plugins that were compiled against a newer IW4MAdmin API than the
+/// running instance provides. Lives in SharedLibraryCore so both the host (Application) and the
+/// central event dispatch can soft-fail consistently with a single friendly notice per plugin.
+/// </summary>
+public static class PluginApiCompatibility
+{
+    // plugins already reported this process, so the notice fires once even though events fire often
+    private static readonly HashSet<string> Reported = [];
+    private static readonly Lock ReportLock = new();
+
+    /// <summary>
+    /// exception types raised when an assembly references a type/member that does not exist in the
+    /// currently loaded SharedLibraryCore (i.e. the plugin needs a newer IW4MAdmin)
+    /// </summary>
+    private static bool IsMissingApiCore(Exception exception) => exception is TypeLoadException
+        or MissingMethodException or MissingFieldException or MissingMemberException
+        or FileNotFoundException or FileLoadException;
+
+    /// <summary>
+    /// true when the exception (or any inner / loader exception) indicates the plugin needs a newer
+    /// IW4MAdmin API than is available
+    /// </summary>
+    public static bool IsMissingApiException(Exception exception)
+    {
+        while (exception is not null)
+        {
+            if (IsMissingApiCore(exception) ||
+                (exception is ReflectionTypeLoadException rtle &&
+                 rtle.LoaderExceptions.Any(loaderException =>
+                     loaderException is not null && IsMissingApiCore(loaderException))))
+            {
+                return true;
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// gets the loadable types from an assembly, tolerating plugins built against a newer API.
+    /// Types whose signatures resolve are returned and still load; types that need unavailable API
+    /// are dropped and a single friendly notice is surfaced per assembly.
+    /// </summary>
+    public static IEnumerable<Type> GetLoadableTypes(Assembly assembly, ILogger logger)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            if (ex.LoaderExceptions.Any(loaderException =>
+                    loaderException is not null && IsMissingApiCore(loaderException)))
+            {
+                NotifyNewerApiRequired(assembly, logger);
+            }
+
+            // surface the types that did resolve so plugins that don't actually use the missing
+            // API continue to load normally
+            return ex.Types.Where(type => type is not null)!;
+        }
+        catch (Exception ex) when (IsMissingApiException(ex))
+        {
+            NotifyNewerApiRequired(assembly, logger);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// walks an exception (and its inner exceptions) to find the assembly whose code raised it,
+    /// so a runtime missing-API failure can be attributed to the offending plugin
+    /// </summary>
+    public static Assembly TryGetOffendingAssembly(Exception exception)
+    {
+        while (exception is not null)
+        {
+            var assembly = exception.TargetSite?.DeclaringType?.Assembly;
+            if (assembly is not null)
+            {
+                return assembly;
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// emits a user-facing notice (console + log) that a plugin could not be loaded/run because it
+    /// targets a newer IW4MAdmin API. Reports at most once per plugin for the life of the process.
+    /// </summary>
+    public static void NotifyNewerApiRequired(Assembly assembly, ILogger logger, string displayName = null)
+    {
+        var key = assembly?.FullName ?? displayName;
+        if (key is not null)
+        {
+            lock (ReportLock)
+            {
+                if (!Reported.Add(key))
+                {
+                    return;
+                }
+            }
+        }
+
+        var pluginName = displayName ?? assembly?.GetName().Name ?? "A plugin";
+        Console.WriteLine(
+            $"[Plugin] {pluginName} uses newer/unavailable IW4MAdmin API. Please update IW4MAdmin to load it.");
+        logger?.LogWarning(
+            "{Plugin} could not be fully loaded because it targets a newer IW4MAdmin API than this instance provides",
+            pluginName);
+    }
+}

--- a/SharedLibraryCore/Helpers/UnavailablePlugin.cs
+++ b/SharedLibraryCore/Helpers/UnavailablePlugin.cs
@@ -1,0 +1,28 @@
+using SharedLibraryCore.Interfaces;
+
+namespace SharedLibraryCore.Helpers;
+
+/// <summary>
+/// Inert placeholder substituted for a plugin that could not be constructed
+/// because it targets API this (older) IW4MAdmin host does not have. It keeps the
+/// plugin out of the way without putting a null into the resolved
+/// <see cref="IPluginV2"/> / <see cref="IPlugin"/> collections (which the DI
+/// container cannot drop mid-enumeration). It does nothing and subscribes to
+/// nothing. The user has already been told to update via
+/// <see cref="PluginApiCompatibility.NotifyNewerApiRequired"/>.
+/// </summary>
+public sealed class UnavailablePlugin(string name) : IPluginV2, IPlugin
+{
+    public string Name { get; } = name;
+    public string Author => "unavailable";
+
+    // IModularAssembly/IPluginV2 version is a string; legacy IPlugin version is a
+    // float, so the latter is implemented explicitly to avoid the clash.
+    public string Version => "0";
+    float IPlugin.Version => 0f;
+
+    public Task OnLoadAsync(IManager manager) => Task.CompletedTask;
+    public Task OnUnloadAsync() => Task.CompletedTask;
+    public Task OnEventAsync(GameEvent gameEvent, Server server) => Task.CompletedTask;
+    public Task OnTickAsync(Server server) => Task.CompletedTask;
+}

--- a/WebfrontCore/Core/Services/WebfrontDataService.cs
+++ b/WebfrontCore/Core/Services/WebfrontDataService.cs
@@ -99,8 +99,10 @@ public class WebfrontDataService : IWebfrontDataService
         _remoteCommandService = remoteCommandService;
         _translationLookup = translationLookup;
         _appConfig = appConfig;
-        _pluginTypeNames = v1Plugins.Select(plugin => (plugin.GetType(), plugin.Name))
-            .Concat(v2Plugins.Select(plugin => (plugin.GetType(), plugin.Name)))
+        _pluginTypeNames = v1Plugins.Where(plugin => plugin is not UnavailablePlugin)
+            .Select(plugin => (plugin.GetType(), plugin.Name))
+            .Concat(v2Plugins.Where(plugin => plugin is not UnavailablePlugin)
+                .Select(plugin => (plugin.GetType(), plugin.Name)))
             .ToLookup(selector => selector.Item1, selector => selector.Name);
         _announcementService = announcementService;
         _twoFactorService = twoFactorService;


### PR DESCRIPTION
 ## Problem

  When a plugin is recompiled against the latest SharedLibraryCore and published to the plugin store, older IW4MAdmin
  instances download it and try to load it. If the plugin actually uses API the older host doesn't have, the host throws
  — and because plugins are resolved in bulk via `IEnumerable<IPluginV2>` / `IEnumerable<IPlugin>`, a single bad plugin
  took the whole host down ("Failed to initialize IW4MAdmin").

  We want two things:
  1. **Don't break plugins that still work.** A plugin versioned against the latest API but only using members the older
  host *does* have should continue to load and run normally.
  2. **Soft-fail the rest.** A plugin that genuinely uses unavailable API should produce a single friendly notice
  ("update IW4MAdmin to load it") instead of crashing the host.

  A minimum-version attribute was deliberately rejected: it requires the author to know the correct minimum, which isn't
  mechanically inferable without a complete API-change lookup table we've never maintained. Instead this keys off the
  runtime exceptions the CLR already raises for missing types/members.

  ## How

  `SharedLibraryCore.Helpers.PluginApiCompatibility` centralises the logic (in SLC so both the host and the event
  dispatch can use it):
  - Classifies missing-API exceptions (`TypeLoadException`, `MissingMethod/Field/MemberException`,
  `FileNotFound/LoadException`), walking inner and `ReflectionTypeLoadException` loader exceptions.
  - `GetLoadableTypes` returns the types that *do* resolve and drops the ones that don't — so a plugin that doesn't
  actually touch the missing API loads normally.
  - Reports at most once per plugin (console + log), identified by assembly name.

  Missing-API failures are caught at every plugin execution boundary:
  - **Type discovery** (`PluginImporter`, eventable-type scan) — unresolvable types are dropped.
  - **Construction** — plugins are registered through a guarded factory; a plugin that loads its type fine but throws at
  construction (a ctor-body call, or a member typed with a missing type — neither is resolved at type load) is reported
  and replaced with an inert `UnavailablePlugin` placeholder, so the bulk DI resolve no longer fails. Covers
  `IPluginV2` and legacy `IPlugin`.
  - **Event dispatch** (`EventExtensions.RunHandler`), **`OnLoadAsync`**, **command/plugin event processing**
  (`IW4MServer`), and **`RegisterDependencies`**.

  Also fixes a latent bug surfaced during testing: a plugin loaded from the Plugins directory is also present in the
  AppDomain, so discovery listed it twice — registering and instantiating every such plugin twice. Discovery now dedupes
  by assembly.

  ## Coverage

  | Failure mode | Result |
  |---|---|
  | Missing base type / interface (eager at type load) | dropped at discovery + notice |
  | Missing type in field/property/param (lazy) | soft-fail at construction + notice |
  | Missing API in ctor body | soft-fail at construction + notice |
  | Missing API in handler/method body | soft-fail at dispatch + notice |

  Genuine plugin bugs (NRE, bad config) are unaffected — the missing-API catch is exception-filtered, so real errors
  still surface as errors rather than being swallowed.

  ## Testing

  Verified on an older host (SLC with the new API removed) against plugins compiled against the new API: type-load,
  construction (both member-signature and ctor-body), and handler-runtime cases each soft-fail with one notice and the
  host boots normally. Also validated against a real WIP plugin (ZombieStats) targeting newer API.

  ## Known limitation

  A plugin whose constructor subscribes to a static event *before* throwing on missing API leaves that subscription
  bound to a half-constructed instance. When it fires, missing-API calls soft-fail at dispatch; any other throw is
  logged and swallowed. This is log noise, not a crash, and a strict improvement over the previous fatal behaviour