### PR TITLE
feat(plugins): per-plugin data directories

### DIFF
--- a/Application/ApplicationManager.cs
+++ b/Application/ApplicationManager.cs
@@ -29,6 +29,7 @@ using IW4MAdmin.Application.Configuration;
 using IW4MAdmin.Application.IO;
 using IW4MAdmin.Application.Migration;
 using IW4MAdmin.Application.Plugin.Script;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
@@ -344,8 +345,10 @@ namespace IW4MAdmin.Application
 
         /// <summary>
         /// Applies pending migrations for every plugin database registered via <c>AddDatabase</c>, before
-        /// plugins receive the <c>Load</c> event. Each migration runs independently and soft-fails: a bad
-        /// plugin migration disables only that database, never the host or other plugins.
+        /// plugins receive the <c>Load</c> event. The registration is pure data (a context accessor); the
+        /// host owns the setup here — apply migrations, then set WAL. Each database is set up independently
+        /// and soft-fails: a bad plugin migration disables only that database, never the host or other
+        /// plugins.
         /// </summary>
         private async Task MigratePluginDatabasesAsync(CancellationToken token)
         {
@@ -359,7 +362,11 @@ namespace IW4MAdmin.Application
             {
                 try
                 {
-                    await registration.MigrateAsync(token);
+                    await using var context = registration.CreateContext();
+                    await context.Database.MigrateAsync(token);
+                    // WAL lets readers proceed during writes; it is a persistent setting, so applying it
+                    // once after migration is enough. Plugin databases are SQLite by design.
+                    await context.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;", token);
                     _logger.LogInformation("Migrated plugin database {Context} at {Path}",
                         registration.ContextName, registration.DatabasePath);
                 }

--- a/Application/ApplicationManager.cs
+++ b/Application/ApplicationManager.cs
@@ -5,6 +5,7 @@ using SharedLibraryCore;
 using SharedLibraryCore.Commands;
 using SharedLibraryCore.Configuration;
 using SharedLibraryCore.Configuration.Validation;
+using SharedLibraryCore.Database;
 using SharedLibraryCore.Database.Models;
 using SharedLibraryCore.Exceptions;
 using SharedLibraryCore.Helpers;
@@ -341,6 +342,36 @@ namespace IW4MAdmin.Application
             await server.ProcessUpdatesAsync(CancellationToken.None);
         }
 
+        /// <summary>
+        /// Applies pending migrations for every plugin database registered via <c>AddDatabase</c>, before
+        /// plugins receive the <c>Load</c> event. Each migration runs independently and soft-fails: a bad
+        /// plugin migration disables only that database, never the host or other plugins.
+        /// </summary>
+        private async Task MigratePluginDatabasesAsync(CancellationToken token)
+        {
+            var registrations = _serviceProvider.GetServices<PluginDatabaseRegistration>().ToList();
+            if (registrations.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var registration in registrations)
+            {
+                try
+                {
+                    await registration.MigrateAsync(token);
+                    _logger.LogInformation("Migrated plugin database {Context} at {Path}",
+                        registration.ContextName, registration.DatabasePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Could not migrate plugin database {Context} at {Path}; this plugin's database will be unavailable",
+                        registration.ContextName, registration.DatabasePath);
+                }
+            }
+        }
+
         public async Task Init()
         {
             IsRunning = true;
@@ -351,6 +382,7 @@ namespace IW4MAdmin.Application
             Console.WriteLine(_translationLookup["MANAGER_MIGRATION_START"]);
             await ContextSeed.Seed(_serviceProvider.GetRequiredService<IDatabaseContextFactory>(), _isRunningTokenSource.Token);
             await DatabaseHousekeeping.RemoveOldRatings(_serviceProvider.GetRequiredService<IDatabaseContextFactory>(), _isRunningTokenSource.Token);
+            await MigratePluginDatabasesAsync(_isRunningTokenSource.Token);
             _logger.LogInformation("Finished database migration sync");
             Console.WriteLine(_translationLookup["MANAGER_MIGRATION_END"]);
             #endregion

--- a/Application/IO/BaseConfigurationHandlerV2.cs
+++ b/Application/IO/BaseConfigurationHandlerV2.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharedLibraryCore;
+using SharedLibraryCore.Helpers;
 using SharedLibraryCore.Interfaces;
 
 namespace IW4MAdmin.Application.IO;
@@ -56,14 +57,10 @@ public class BaseConfigurationHandlerV2<TConfigurationType> : IConfigurationHand
             return defaultConfiguration;
         }
 
-        var cleanName = configurationName.Replace("\\", "").Replace("/", "");
+        Filename = ResolveConfigurationPath(configurationName);
+        WarnIfTypeNotOwnedByPlugin();
+        MigrateLegacyConfiguration(configurationName, Filename);
 
-        if (string.IsNullOrWhiteSpace(configurationName))
-        {
-            return defaultConfiguration;
-        }
-
-        Filename = Path.Join(Utilities.OperatingDirectory, "Configuration", $"{cleanName}.json");
         TConfigurationType readConfiguration = null;
 
         try
@@ -209,6 +206,93 @@ public class BaseConfigurationHandlerV2<TConfigurationType> : IConfigurationHand
             {
                 property.SetValue(_configurationInstance, property.GetValue(newConfiguration));
             }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the on-disk path for this configuration. Types defined in a host/framework assembly
+    /// keep the legacy flat <c>Configuration/</c> location; everything else (a plugin, in any load
+    /// format) routes to its own <c>Plugins/&lt;key&gt;/</c> folder. The configuration name may contain
+    /// forward-slash segments to nest the file in a subfolder; segments are sanitized and the result is
+    /// constrained to the resolved root.
+    /// </summary>
+    private static string ResolveConfigurationPath(string configurationName)
+    {
+        var assembly = typeof(TConfigurationType).Assembly;
+        var root = PluginDirectoryResolver.IsHostAssembly(assembly)
+            ? Path.Join(Utilities.OperatingDirectory, "Configuration")
+            : PluginDirectoryResolver.ResolveDirectory(assembly);
+
+        return PluginDirectoryResolver.CombineWithinRoot(root, configurationName, ".json");
+    }
+
+    // warns at most once per closed configuration type (this static is per generic instantiation)
+    private static bool _warnedNotOwnedByPlugin;
+
+    /// <summary>
+    /// Warns (but does not block) when this configuration type is defined outside any real plugin — e.g.
+    /// in a shared helper library referenced by several plugins. In that case the folder key is the shared
+    /// library, so multiple plugins would share one folder. Host/framework types and types that live in a
+    /// genuine plugin assembly never warn.
+    /// </summary>
+    private void WarnIfTypeNotOwnedByPlugin()
+    {
+        if (_warnedNotOwnedByPlugin)
+        {
+            return;
+        }
+
+        var assembly = typeof(TConfigurationType).Assembly;
+        if (PluginDirectoryResolver.IsHostAssembly(assembly) ||
+            PluginDirectoryResolver.LooksLikePluginAssembly(assembly))
+        {
+            return;
+        }
+
+        _warnedNotOwnedByPlugin = true;
+        _logger.LogWarning(
+            "Configuration type {Type} is defined in assembly {Assembly}, which does not contain a plugin. " +
+            "It will use the data folder Plugins/{Key}/, shared by any plugin that references this assembly. " +
+            "Define configuration types inside your own plugin to keep its data folder isolated.",
+            typeof(TConfigurationType).Name, assembly.GetName().Name, PluginDirectoryResolver.ResolveKey(assembly));
+    }
+
+    /// <summary>
+    /// One-time relocation of a plugin configuration from the legacy shared <c>Configuration/</c> folder
+    /// into the plugin's own folder. Runs only for plugin configs, only when the target is absent and the
+    /// legacy file is present — so it is idempotent and cannot double-apply across restarts.
+    /// </summary>
+    private void MigrateLegacyConfiguration(string configurationName, string targetPath)
+    {
+        if (PluginDirectoryResolver.IsHostAssembly(typeof(TConfigurationType).Assembly))
+        {
+            return; // host configs already live in Configuration/
+        }
+
+        if (File.Exists(targetPath))
+        {
+            return; // already in the plugin folder (or already migrated)
+        }
+
+        var flatName = configurationName.Replace("\\", string.Empty).Replace("/", string.Empty);
+        var legacyPath = Path.Join(Utilities.OperatingDirectory, "Configuration", $"{flatName}.json");
+
+        if (!File.Exists(legacyPath))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Move(legacyPath, targetPath);
+            _logger.LogInformation(
+                "Migrated plugin configuration {Name} from {OldPath} to {NewPath}", flatName, legacyPath,
+                targetPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not migrate legacy configuration {Name} to {NewPath}", flatName,
+                targetPath);
         }
     }
 }

--- a/Application/IO/BaseConfigurationHandlerV2.cs
+++ b/Application/IO/BaseConfigurationHandlerV2.cs
@@ -261,6 +261,11 @@ public class BaseConfigurationHandlerV2<TConfigurationType> : IConfigurationHand
     /// One-time relocation of a plugin configuration from the legacy shared <c>Configuration/</c> folder
     /// into the plugin's own folder. Runs only for plugin configs, only when the target is absent and the
     /// legacy file is present — so it is idempotent and cannot double-apply across restarts.
+    ///
+    /// This lives on the handler rather than in <c>ConfigurationMigration</c> deliberately: the migration
+    /// needs the <typeparamref name="TConfigurationType"/> → plugin-folder mapping to know which plugin a
+    /// flat <c>Configuration/*.json</c> belongs to, and that type context only exists here at
+    /// config-resolution time. The startup <c>ConfigurationMigration</c> sweep has no such per-type context.
     /// </summary>
     private void MigrateLegacyConfiguration(string configurationName, string targetPath)
     {

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -737,6 +737,7 @@ namespace IW4MAdmin.Application
                 .AddSingleton<IRemoteCommandService, RemoteCommandService>()
                 .AddSingleton(new ConfigurationWatcher())
                 .AddSingleton(typeof(IConfigurationHandlerV2<>), typeof(BaseConfigurationHandlerV2<>))
+                .AddSingleton(typeof(IPluginDataDirectory<>), typeof(PluginDataDirectory<>))
                 .AddSingleton<IScriptPluginFactory, ScriptPluginFactory>()
                 .AddSingleton<CsPluginCompiler>()
                 .AddSingleton<CsPluginFileWatcher>()

--- a/Application/Main.cs
+++ b/Application/Main.cs
@@ -737,7 +737,7 @@ namespace IW4MAdmin.Application
                 .AddSingleton<IRemoteCommandService, RemoteCommandService>()
                 .AddSingleton(new ConfigurationWatcher())
                 .AddSingleton(typeof(IConfigurationHandlerV2<>), typeof(BaseConfigurationHandlerV2<>))
-                .AddSingleton(typeof(IPluginDataDirectory<>), typeof(PluginDataDirectory<>))
+                .AddSingleton(typeof(IPluginDataStore<>), typeof(PluginDataStore<>))
                 .AddSingleton<IScriptPluginFactory, ScriptPluginFactory>()
                 .AddSingleton<CsPluginCompiler>()
                 .AddSingleton<CsPluginFileWatcher>()

--- a/Application/Misc/PageList.cs
+++ b/Application/Misc/PageList.cs
@@ -1,13 +1,11 @@
-﻿using SharedLibraryCore.Interfaces;
-using System;
+using SharedLibraryCore.Interfaces;
 using System.Collections.Generic;
-using System.Text;
 
 namespace IW4MAdmin.Application
 {
     /// <summary>
-    /// implementatin of IPageList that supports basic
-    /// pages title and page location for webfront
+    /// implementation of IPageList that supports a page title, page location,
+    /// and an optional navbar icon for the webfront
     /// </summary>
     class PageList : IPageList
     {
@@ -18,9 +16,25 @@ namespace IW4MAdmin.Application
         /// </summary>
         public IDictionary<string, string> Pages { get; set; }
 
+        /// <summary>
+        /// Optional navbar icon per page name (Phosphor icon class, e.g. "ph-detective").
+        /// </summary>
+        public IDictionary<string, string> PageIcons { get; }
+
         public PageList()
         {
             Pages = new Dictionary<string, string>();
+            PageIcons = new Dictionary<string, string>();
+        }
+
+        public void AddPage(string name, string location, string icon = null)
+        {
+            Pages[name] = location;
+
+            if (!string.IsNullOrWhiteSpace(icon))
+            {
+                PageIcons[name] = icon;
+            }
         }
     }
 }

--- a/Application/Plugin/PluginDataDirectory.cs
+++ b/Application/Plugin/PluginDataDirectory.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using SharedLibraryCore.Helpers;
+using SharedLibraryCore.Interfaces;
+
+namespace IW4MAdmin.Application.Plugin;
+
+/// <summary>
+/// Default <see cref="IPluginDataDirectory{TPlugin}"/> implementation. Resolves the folder from the
+/// plugin's own assembly (<see cref="PluginDirectoryResolver"/>) and lazily creates it. Origin of the
+/// assembly is irrelevant — disk DLL, in-memory compiled <c>.cs</c> script, local/remote <c>.zip</c>
+/// bundle, or a binary streamed from the remote store all resolve by assembly name alone.
+/// </summary>
+public sealed class PluginDataDirectory<TPlugin> : IPluginDataDirectory<TPlugin>
+{
+    private readonly Lazy<string> _root = new(() =>
+    {
+        var path = PluginDirectoryResolver.ResolveDirectory(typeof(TPlugin).Assembly);
+        Directory.CreateDirectory(path);
+        return path;
+    });
+
+    public string RootPath => _root.Value;
+
+    public string GetPath(params string[] segments)
+    {
+        var rootFull = Path.GetFullPath(RootPath);
+
+        if (segments is null || segments.Length == 0)
+        {
+            return rootFull;
+        }
+
+        var combined = Path.GetFullPath(Path.Combine(new[] { rootFull }.Concat(segments).ToArray()));
+
+        // reject anything that resolves outside the plugin folder (e.g. a "../" segment)
+        if (combined != rootFull &&
+            !combined.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Resolved path '{combined}' escapes the plugin data directory '{rootFull}'.");
+        }
+
+        var directory = Path.GetDirectoryName(combined);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return combined;
+    }
+
+    public async Task<string> EnsureAsset(string embeddedResourceName, bool overwrite = false)
+    {
+        if (string.IsNullOrWhiteSpace(embeddedResourceName))
+        {
+            throw new ArgumentException("Resource name cannot be null or empty.", nameof(embeddedResourceName));
+        }
+
+        var target = GetPath(embeddedResourceName.Split('/', '\\'));
+
+        if (File.Exists(target) && !overwrite)
+        {
+            return target;
+        }
+
+        var assembly = typeof(TPlugin).Assembly;
+        await using var resourceStream = ResolveManifestResource(assembly, embeddedResourceName)
+            ?? throw new FileNotFoundException(
+                $"Embedded resource '{embeddedResourceName}' was not found in assembly '{assembly.GetName().Name}'.");
+
+        await using var outputStream = File.Create(target);
+        await resourceStream.CopyToAsync(outputStream);
+        return target;
+    }
+
+    /// <summary>
+    /// Looks up an embedded resource by exact manifest name first, then by suffix (manifest names are
+    /// namespace-prefixed and dot-separated, so an author-friendly "folder/file" rarely matches exactly).
+    /// </summary>
+    private static Stream ResolveManifestResource(Assembly assembly, string name)
+    {
+        var direct = assembly.GetManifestResourceStream(name);
+        if (direct is not null)
+        {
+            return direct;
+        }
+
+        var normalized = name.Replace('/', '.').Replace('\\', '.');
+        var match = assembly.GetManifestResourceNames()
+            .FirstOrDefault(candidate => candidate.EndsWith(normalized, StringComparison.OrdinalIgnoreCase));
+
+        return match is null ? null : assembly.GetManifestResourceStream(match);
+    }
+}

--- a/Application/Plugin/PluginDataStore.cs
+++ b/Application/Plugin/PluginDataStore.cs
@@ -9,12 +9,12 @@ using SharedLibraryCore.Interfaces;
 namespace IW4MAdmin.Application.Plugin;
 
 /// <summary>
-/// Default <see cref="IPluginDataDirectory{TPlugin}"/> implementation. Resolves the folder from the
+/// Default <see cref="IPluginDataStore{TPlugin}"/> implementation. Resolves the folder from the
 /// plugin's own assembly (<see cref="PluginDirectoryResolver"/>) and lazily creates it. Origin of the
 /// assembly is irrelevant — disk DLL, in-memory compiled <c>.cs</c> script, local/remote <c>.zip</c>
 /// bundle, or a binary streamed from the remote store all resolve by assembly name alone.
 /// </summary>
-public sealed class PluginDataDirectory<TPlugin> : IPluginDataDirectory<TPlugin>
+public sealed class PluginDataStore<TPlugin> : IPluginDataStore<TPlugin>
 {
     private readonly Lazy<string> _root = new(() =>
     {
@@ -60,7 +60,7 @@ public sealed class PluginDataDirectory<TPlugin> : IPluginDataDirectory<TPlugin>
             throw new ArgumentException("Resource name cannot be null or empty.", nameof(embeddedResourceName));
         }
 
-        var target = GetPath(embeddedResourceName.Split('/', '\\'));
+        var target = GetPath(embeddedResourceName.Split(SharedLibraryCore.Utilities.DirectorySeparatorChars));
 
         if (File.Exists(target) && !overwrite)
         {

--- a/Application/Plugin/PluginImporter.cs
+++ b/Application/Plugin/PluginImporter.cs
@@ -221,6 +221,9 @@ namespace IW4MAdmin.Application.Plugin
                 return (pluginTypes, commandTypes, configurationTypes);
             }
 
+            // this short list is a build-reference filter for AppDomain discovery only — it is NOT the
+            // host-assembly set used for data-directory routing (see PluginDirectoryResolver.HostAssemblies),
+            // which is a different membership and purpose; do not fold the two together
             var eligibleAssemblyTypes = assemblies.Concat(AppDomain.CurrentDomain.GetAssemblies()
                     .Where(asm => !new[] { "IW4MAdmin", "SharedLibraryCore", "Stats" }.Contains(asm.GetName().Name)))
                 // a plugin loaded from the Plugins dir is also present in the AppDomain, so the

--- a/Application/Plugin/PluginImporter.cs
+++ b/Application/Plugin/PluginImporter.cs
@@ -333,7 +333,7 @@ namespace IW4MAdmin.Application.Plugin
                             continue;
                         }
 
-                        ExtractBundleGameScripts(bundle);
+                        ExtractBundleToSandbox(bundle);
                         AddCandidate(candidates, bundle.Assembly, "remote-store-bundle",
                             $"remote store (content type: zip, {byteCount:N0} bytes, bundle id '{bundle.Id}', manifest version '{bundle.Manifest.Version}')");
                     }
@@ -380,7 +380,7 @@ namespace IW4MAdmin.Application.Plugin
                         continue;
                     }
 
-                    ExtractBundleGameScripts(bundle);
+                    ExtractBundleToSandbox(bundle);
                     AddCandidate(candidates, bundle.Assembly,
                         source.IsZip ? "disk-bundle-zip" : "disk-bundle-dir",
                         $"{source.Path} (bundle id '{bundle.Id}', manifest version '{bundle.Manifest.Version}')");
@@ -423,34 +423,53 @@ namespace IW4MAdmin.Application.Plugin
         }
 
         /// <summary>
-        /// Writes a bundle's GSC files to the configured game-files folder. GSC is the only bundle content
-        /// written to disk; when no path is configured, extraction is skipped.
+        /// Extracts a bundle's data files to the plugin's own sandbox folder (<c>Plugins/&lt;id&gt;/</c>):
+        /// generic resources to <c>Resources/</c>, and game scripts to <c>gsc/</c>. Game scripts are treated as
+        /// a sandboxed resource — the instance owner copies them onto their game server; nothing is delivered to
+        /// a shared location, and no operator config is required.
         /// </summary>
-        private void ExtractBundleGameScripts(LoadedBundle bundle)
+        private void ExtractBundleToSandbox(LoadedBundle bundle)
         {
-            if (bundle.GscFiles.Count == 0)
+            var sandbox = SharedLibraryCore.Helpers.PluginDirectoryResolver.ResolveDirectory(bundle.Assembly);
+
+            if (bundle.ResourceFiles.Count > 0)
             {
-                return;
+                var target = Path.Combine(sandbox, "Resources");
+                WriteBundleFiles(bundle.ResourceFiles, target, skipUnchanged: true);
+                _logger.LogInformation("Extracted {Count} resource file(s) from bundle {Id} to {Path}",
+                    bundle.ResourceFiles.Count, bundle.Id, target);
             }
 
-            var targetPath = appConfig.PluginGscExtractPath;
-            if (string.IsNullOrWhiteSpace(targetPath))
+            if (bundle.GscFiles.Count > 0)
             {
-                _logger.LogDebug(
-                    "Bundle {Id} ships {Count} GSC file(s) but PluginGscExtractPath is not configured; skipping extraction",
-                    bundle.Id, bundle.GscFiles.Count);
-                return;
+                var target = Path.Combine(sandbox, "gsc");
+                WriteBundleFiles(bundle.GscFiles, target, skipUnchanged: true);
+                _logger.LogInformation(
+                    "Extracted {Count} game-script file(s) from bundle {Id} to {Path} — copy these to your game server's scripts folder",
+                    bundle.GscFiles.Count, bundle.Id, target);
             }
+        }
 
-            foreach (var (relativePath, content) in bundle.GscFiles)
+        /// <summary>
+        /// Writes bundle files to disk under <paramref name="targetPath"/>, preserving sub-paths. When
+        /// <paramref name="skipUnchanged"/> is set, a file already present at the same byte length is left
+        /// alone — avoids rewriting large data files (e.g. GeoIP databases) on every load.
+        /// </summary>
+        private static void WriteBundleFiles(IReadOnlyDictionary<string, byte[]> files, string targetPath,
+            bool skipUnchanged)
+        {
+            foreach (var (relativePath, content) in files)
             {
                 var destination = Path.Combine(targetPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+
+                if (skipUnchanged && File.Exists(destination) && new FileInfo(destination).Length == content.Length)
+                {
+                    continue;
+                }
+
                 File.WriteAllBytes(destination, content);
             }
-
-            _logger.LogInformation("Extracted {Count} GSC file(s) from bundle {Id} to {Path}",
-                bundle.GscFiles.Count, bundle.Id, targetPath);
         }
     }
 

--- a/Plugins/LiveRadar/Plugin.cs
+++ b/Plugins/LiveRadar/Plugin.cs
@@ -146,8 +146,8 @@ public class Plugin : IPluginV2
                 return Task.CompletedTask;
             }
 
-            (monitorEvent.Source as IManager)?.GetPageList().Pages
-                .Add(Utilities.CurrentLocalization.LocalizationIndex["WEBFRONT_RADAR_TITLE"], "/radar");
+            (monitorEvent.Source as IManager)?.GetPageList()
+                .AddPage(Utilities.CurrentLocalization.LocalizationIndex["WEBFRONT_RADAR_TITLE"], "/radar", "ph-wifi-high");
             _addedPage = true;
         }
 

--- a/SharedLibraryCore/Configuration/ApplicationConfiguration.cs
+++ b/SharedLibraryCore/Configuration/ApplicationConfiguration.cs
@@ -188,12 +188,6 @@ namespace SharedLibraryCore.Configuration
         [ConfigurationIgnore] public string Id { get; set; }
         [ConfigurationIgnore] public string SubscriptionId { get; set; }
 
-        /// <summary>
-        /// Optional filesystem path to which plugin bundles' game-side scripts (GSC) are extracted on load.
-        /// When null/empty, GSC extraction is skipped. GSC is the only bundle content written to disk.
-        /// </summary>
-        [ConfigurationIgnore] public string PluginGscExtractPath { get; set; }
-
         [ConfigurationIgnore]
         [JsonIgnore]
         public string WebfrontUrl => string.IsNullOrEmpty(Webfront.ManualUrl)

--- a/SharedLibraryCore/Database/PluginDatabaseRegistration.cs
+++ b/SharedLibraryCore/Database/PluginDatabaseRegistration.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharedLibraryCore.Database;
+
+/// <summary>
+/// A record of a plugin database registered via <c>AddDatabase&lt;TContext&gt;</c>. The host resolves
+/// every <see cref="PluginDatabaseRegistration"/> at startup and runs <see cref="MigrateAsync"/> for each
+/// — before plugins receive the management <c>Load</c> event — so a plugin's schema is ready before its
+/// first query. Each migration is run independently so one failure disables only that database.
+/// </summary>
+public sealed class PluginDatabaseRegistration
+{
+    public PluginDatabaseRegistration(string contextName, string databasePath,
+        Func<CancellationToken, Task> migrateAsync)
+    {
+        ContextName = contextName;
+        DatabasePath = databasePath;
+        MigrateAsync = migrateAsync;
+    }
+
+    /// <summary>The context type name (for diagnostics).</summary>
+    public string ContextName { get; }
+
+    /// <summary>Absolute path to the SQLite file backing this context.</summary>
+    public string DatabasePath { get; }
+
+    /// <summary>Applies pending migrations and sets WAL for this context.</summary>
+    public Func<CancellationToken, Task> MigrateAsync { get; }
+}

--- a/SharedLibraryCore/Database/PluginDatabaseRegistration.cs
+++ b/SharedLibraryCore/Database/PluginDatabaseRegistration.cs
@@ -1,23 +1,24 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 
 namespace SharedLibraryCore.Database;
 
 /// <summary>
-/// A record of a plugin database registered via <c>AddDatabase&lt;TContext&gt;</c>. The host resolves
-/// every <see cref="PluginDatabaseRegistration"/> at startup and runs <see cref="MigrateAsync"/> for each
-/// — before plugins receive the management <c>Load</c> event — so a plugin's schema is ready before its
-/// first query. Each migration is run independently so one failure disables only that database.
+/// A declarative record of a plugin database registered via <c>AddDatabase&lt;TContext&gt;</c>. It carries
+/// only data — the context type name, the backing file path, and a non-generic accessor that constructs
+/// the plugin's <see cref="DbContext"/>. The host resolves every <see cref="PluginDatabaseRegistration"/>
+/// at startup and owns the "how" (apply migrations, set WAL) — before plugins receive the management
+/// <c>Load</c> event — so a plugin's schema is ready before its first query. Each database is set up
+/// independently so one failure disables only that database.
 /// </summary>
 public sealed class PluginDatabaseRegistration
 {
     public PluginDatabaseRegistration(string contextName, string databasePath,
-        Func<CancellationToken, Task> migrateAsync)
+        Func<DbContext> createContext)
     {
         ContextName = contextName;
         DatabasePath = databasePath;
-        MigrateAsync = migrateAsync;
+        CreateContext = createContext;
     }
 
     /// <summary>The context type name (for diagnostics).</summary>
@@ -26,6 +27,6 @@ public sealed class PluginDatabaseRegistration
     /// <summary>Absolute path to the SQLite file backing this context.</summary>
     public string DatabasePath { get; }
 
-    /// <summary>Applies pending migrations and sets WAL for this context.</summary>
-    public Func<CancellationToken, Task> MigrateAsync { get; }
+    /// <summary>Constructs the plugin's context so the host can apply migrations and set up the database.</summary>
+    public Func<DbContext> CreateContext { get; }
 }

--- a/SharedLibraryCore/Database/PluginDbContextFactory.cs
+++ b/SharedLibraryCore/Database/PluginDbContextFactory.cs
@@ -9,6 +9,11 @@ namespace SharedLibraryCore.Database;
 /// non-generic <c>DbContextOptions</c> into the shared host container, where it would collide with the
 /// host's own <c>DbContext</c>. SQLite by design: a plugin database is self-contained and never shares
 /// the host's provider or schema.
+///
+/// Kept separate from the host's <c>DatabaseContextFactory</c> on purpose — that factory returns the one
+/// concrete host <c>DatabaseContext</c> and switches Postgres/MySQL/SQLite by config, whereas this is a
+/// generic per-plugin <c>IDbContextFactory{TContext}</c>, one instance per plugin context, SQLite-only.
+/// Different return type, provider scope, and lifetime; folding them together would fit neither.
 /// </summary>
 public sealed class PluginDbContextFactory<TContext> : IDbContextFactory<TContext>
     where TContext : DbContext

--- a/SharedLibraryCore/Database/PluginDbContextFactory.cs
+++ b/SharedLibraryCore/Database/PluginDbContextFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace SharedLibraryCore.Database;
+
+/// <summary>
+/// Runtime <see cref="IDbContextFactory{TContext}"/> for a plugin-owned database. Holds the options
+/// privately and is registered by hand (never via <c>AddDbContextFactory</c>) so EF does not register a
+/// non-generic <c>DbContextOptions</c> into the shared host container, where it would collide with the
+/// host's own <c>DbContext</c>. SQLite by design: a plugin database is self-contained and never shares
+/// the host's provider or schema.
+/// </summary>
+public sealed class PluginDbContextFactory<TContext> : IDbContextFactory<TContext>
+    where TContext : DbContext
+{
+    private readonly DbContextOptions<TContext> _options;
+
+    public PluginDbContextFactory(string connectionString)
+    {
+        _options = new DbContextOptionsBuilder<TContext>()
+            .UseSqlite(connectionString)
+            .Options;
+    }
+
+    public TContext CreateDbContext() =>
+        (TContext)(Activator.CreateInstance(typeof(TContext), _options)
+                   ?? throw new InvalidOperationException(
+                       $"Could not construct {typeof(TContext).Name}; it must have a public " +
+                       $"constructor taking DbContextOptions<{typeof(TContext).Name}>."));
+}

--- a/SharedLibraryCore/Dtos/Page.cs
+++ b/SharedLibraryCore/Dtos/Page.cs
@@ -1,8 +1,14 @@
-﻿namespace SharedLibraryCore.Dtos
+namespace SharedLibraryCore.Dtos
 {
     public class Page
     {
         public string Name { get; set; }
         public string Location { get; set; }
+
+        /// <summary>
+        /// Optional navbar icon, as a Phosphor icon class (e.g. "ph-detective").
+        /// When null/empty the webfront falls back to its default page icon.
+        /// </summary>
+        public string IconId { get; set; }
     }
 }

--- a/SharedLibraryCore/Helpers/PluginDirectoryResolver.cs
+++ b/SharedLibraryCore/Helpers/PluginDirectoryResolver.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace SharedLibraryCore.Helpers;
+
+/// <summary>
+/// Resolves the on-disk data directory for a plugin from a type it defines. Identity comes from
+/// <c>typeof(T).Assembly.GetName().Name</c> — the host's canonical plugin identifier — so it works
+/// uniformly across every plugin format: compiled <c>.dll</c>, in-memory compiled <c>.cs</c> scripts
+/// (assembly named after the file), and <c>.zip</c> bundles (the bundle's compiled assembly).
+///
+/// Routing is by elimination: a type defined in a host/framework assembly keeps the legacy flat
+/// <c>Configuration/</c> behavior; everything else is a plugin and routes to <c>Plugins/&lt;key&gt;/</c>.
+/// This avoids depending on membership in any discovery set (script assemblies are not enumerated
+/// there).
+/// </summary>
+public static class PluginDirectoryResolver
+{
+    /// <summary>
+    /// Framework/host assemblies whose types are *not* plugins. Types defined here keep the legacy
+    /// flat configuration location. Anything outside this set is treated as a plugin.
+    /// </summary>
+    private static readonly HashSet<string> HostAssemblies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "IW4MAdmin",
+        "SharedLibraryCore",
+        "Data",
+        "WebfrontCore",
+        "WebCommon",
+        "Integrations.Cod",
+        "Integrations.Source"
+    };
+
+    /// <summary>
+    /// True when the assembly is a host/framework assembly (its types route to the legacy flat
+    /// configuration directory rather than a per-plugin folder).
+    /// </summary>
+    public static bool IsHostAssembly(Assembly assembly) =>
+        HostAssemblies.Contains(assembly.GetName().Name ?? string.Empty);
+
+    /// <summary>
+    /// The sanitized folder key for a plugin assembly (the DLL / script-file / bundle assembly name).
+    /// </summary>
+    public static string ResolveKey(Assembly assembly) => Sanitize(assembly.GetName().Name ?? "Unknown");
+
+    private static readonly ConcurrentDictionary<Assembly, bool> PluginAssemblyCache = new();
+
+    /// <summary>
+    /// True when the assembly actually contains a plugin (an <c>IPluginV2</c>/<c>IPlugin</c>
+    /// implementation). A genuine plugin — compiled, scripted, bundled, or streamed — always defines its
+    /// own plugin type here, whereas a shared helper library referenced by several plugins does not. Used
+    /// to warn (but not block) when a config/context type lives outside any real plugin, since its folder
+    /// key would then be the shared library rather than a single plugin.
+    /// </summary>
+    public static bool LooksLikePluginAssembly(Assembly assembly) =>
+        PluginAssemblyCache.GetOrAdd(assembly, static asm =>
+        {
+            try
+            {
+                return asm.GetTypes().Any(type =>
+                    type is { IsInterface: false, IsAbstract: false } &&
+                    (type.GetInterface("IPluginV2") is not null || type.GetInterface("IPlugin") is not null));
+            }
+            catch
+            {
+                // could not introspect the assembly; assume it is fine and stay quiet
+                return true;
+            }
+        });
+
+    /// <summary>
+    /// Absolute path to a plugin's data folder: <c>Plugins/&lt;key&gt;/</c>, co-located with the binary.
+    /// </summary>
+    public static string ResolveDirectory(Assembly assembly) =>
+        Path.Combine(Utilities.PluginsDirectory, ResolveKey(assembly));
+
+    /// <summary>
+    /// Resolves a file path under <paramref name="root"/> from a caller-supplied name that may contain
+    /// forward-slash subfolder segments. Each segment is sanitized, <paramref name="extension"/> is
+    /// appended if absent, intermediate directories are created, and the result is constrained to the
+    /// root (a name that would escape throws).
+    /// </summary>
+    public static string CombineWithinRoot(string root, string name, string extension)
+    {
+        var rootFull = Path.GetFullPath(root);
+
+        var segments = (name ?? string.Empty)
+            .Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(Sanitize)
+            .ToArray();
+
+        if (segments.Length == 0)
+        {
+            segments = ["Unknown"];
+        }
+
+        if (!segments[^1].EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+        {
+            segments[^1] += extension;
+        }
+
+        var combined = Path.GetFullPath(Path.Combine([rootFull, .. segments]));
+
+        if (combined != rootFull &&
+            !combined.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Name '{name}' resolves outside '{rootFull}'.");
+        }
+
+        var directory = Path.GetDirectoryName(combined);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return combined;
+    }
+
+    /// <summary>
+    /// Strips characters illegal in a file name and defends against relative-path tokens, collapsing
+    /// the result to a safe, stable folder name. Never returns empty.
+    /// </summary>
+    public static string Sanitize(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "Unknown";
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(name.Where(c => !invalid.Contains(c)).ToArray());
+        // collapse any residual relative-path tokens and avoid leading/trailing dots
+        cleaned = cleaned.Replace("..", string.Empty).Trim().Trim('.');
+        return string.IsNullOrWhiteSpace(cleaned) ? "Unknown" : cleaned;
+    }
+}

--- a/SharedLibraryCore/Helpers/PluginDirectoryResolver.cs
+++ b/SharedLibraryCore/Helpers/PluginDirectoryResolver.cs
@@ -88,7 +88,7 @@ public static class PluginDirectoryResolver
         var rootFull = Path.GetFullPath(root);
 
         var segments = (name ?? string.Empty)
-            .Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries)
+            .Split(Utilities.DirectorySeparatorChars, StringSplitOptions.RemoveEmptyEntries)
             .Select(Sanitize)
             .ToArray();
 

--- a/SharedLibraryCore/Interfaces/IPageList.cs
+++ b/SharedLibraryCore/Interfaces/IPageList.cs
@@ -1,9 +1,27 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace SharedLibraryCore.Interfaces
 {
     public interface IPageList
     {
+        /// <summary>
+        /// Registered navbar pages. Key = page name, value = page location (url).
+        /// </summary>
         IDictionary<string, string> Pages { get; set; }
+
+        /// <summary>
+        /// Optional navbar icon per page name, as a Phosphor icon class (e.g. "ph-detective").
+        /// Populated by <see cref="AddPage"/>; pages absent from this map use the webfront default icon.
+        /// </summary>
+        IDictionary<string, string> PageIcons { get; }
+
+        /// <summary>
+        /// Registers a navbar page with an optional icon.
+        /// </summary>
+        /// <param name="name">Display name shown in the navbar.</param>
+        /// <param name="location">Page location (url).</param>
+        /// <param name="icon">Optional Phosphor icon class (e.g. "ph-detective"). When null/empty the
+        /// webfront uses its default page icon.</param>
+        void AddPage(string name, string location, string icon = null);
     }
 }

--- a/SharedLibraryCore/Interfaces/IPluginDataDirectory.cs
+++ b/SharedLibraryCore/Interfaces/IPluginDataDirectory.cs
@@ -1,0 +1,37 @@
+namespace SharedLibraryCore.Interfaces;
+
+/// <summary>
+/// A plugin's own isolated data directory on disk — <c>Plugins/&lt;plugin&gt;/</c>, next to the
+/// plugin binary. Inject <c>IPluginDataDirectory&lt;YourPlugin&gt;</c> to read and write files your
+/// plugin owns (caches, exports, seeded assets — anything that is not a routed config or database).
+///
+/// The folder name is derived from the plugin's own assembly and the directory is created on first
+/// access; callers only ever use relative paths inside it. This mirrors PaperMC's
+/// <c>getDataFolder()</c>: the host owns "where", the plugin owns "what".
+/// </summary>
+/// <typeparam name="TPlugin">
+/// The plugin's own type (any type defined in the plugin assembly). Its assembly identifies the
+/// folder, so the same instance is shared by everything in that plugin.
+/// </typeparam>
+public interface IPluginDataDirectory<TPlugin>
+{
+    /// <summary>
+    /// Absolute path to the plugin's data folder. Created on first access.
+    /// </summary>
+    string RootPath { get; }
+
+    /// <summary>
+    /// Resolves a path inside the plugin folder, creating any intermediate directories along the way
+    /// (e.g. <c>GetPath("playerdata", "42", "stats.json")</c>). Throws if the resulting path would
+    /// escape the plugin folder.
+    /// </summary>
+    string GetPath(params string[] segments);
+
+    /// <summary>
+    /// Copies a resource embedded in the plugin assembly out into the plugin folder on first run
+    /// (handy for seeding a default file). No-op when the target already exists unless
+    /// <paramref name="overwrite"/> is set. Nested resource paths are supported. Returns the written
+    /// path.
+    /// </summary>
+    Task<string> EnsureAsset(string embeddedResourceName, bool overwrite = false);
+}

--- a/SharedLibraryCore/Interfaces/IPluginDataStore.cs
+++ b/SharedLibraryCore/Interfaces/IPluginDataStore.cs
@@ -1,8 +1,8 @@
 namespace SharedLibraryCore.Interfaces;
 
 /// <summary>
-/// A plugin's own isolated data directory on disk — <c>Plugins/&lt;plugin&gt;/</c>, next to the
-/// plugin binary. Inject <c>IPluginDataDirectory&lt;YourPlugin&gt;</c> to read and write files your
+/// A handle to a plugin's own isolated data directory on disk — <c>Plugins/&lt;plugin&gt;/</c>, next to
+/// the plugin binary. Inject <c>IPluginDataStore&lt;YourPlugin&gt;</c> to read and write files your
 /// plugin owns (caches, exports, seeded assets — anything that is not a routed config or database).
 ///
 /// The folder name is derived from the plugin's own assembly and the directory is created on first
@@ -13,7 +13,7 @@ namespace SharedLibraryCore.Interfaces;
 /// The plugin's own type (any type defined in the plugin assembly). Its assembly identifies the
 /// folder, so the same instance is shared by everything in that plugin.
 /// </typeparam>
-public interface IPluginDataDirectory<TPlugin>
+public interface IPluginDataStore<TPlugin>
 {
     /// <summary>
     /// Absolute path to the plugin's data folder. Created on first access.

--- a/SharedLibraryCore/Packaging/RaidMax.IW4MAdmin.SharedLibraryCore.targets
+++ b/SharedLibraryCore/Packaging/RaidMax.IW4MAdmin.SharedLibraryCore.targets
@@ -115,6 +115,7 @@ foreach (var kv in byClass)
 
         <IW4MAdminWebRoot Condition="'$(IW4MAdminWebRoot)' == ''">$(MSBuildProjectDirectory)\wwwroot</IW4MAdminWebRoot>
         <IW4MAdminGscRoot Condition="'$(IW4MAdminGscRoot)' == ''">$(MSBuildProjectDirectory)\gsc</IW4MAdminGscRoot>
+        <IW4MAdminResourceRoot Condition="'$(IW4MAdminResourceRoot)' == ''">$(MSBuildProjectDirectory)\Resources</IW4MAdminResourceRoot>
     </PropertyGroup>
 
     <!-- the host provides SharedLibraryCore and its dependency closure at runtime, so don't bundle them.
@@ -154,7 +155,7 @@ foreach (var kv in byClass)
         </ItemGroup>
 
         <PropertyGroup>
-            <_IW4MManifest>{"schemaVersion":1,"id":"$(IW4MAdminBundleId)","name":"$(IW4MAdminBundleName)","version":"$(IW4MAdminBundleVersion)","author":"$(IW4MAdminBundleAuthor)","entryAssembly":"lib/$(TargetFileName)","webRoot":"wwwroot","gscRoot":"gsc"}</_IW4MManifest>
+            <_IW4MManifest>{"schemaVersion":1,"id":"$(IW4MAdminBundleId)","name":"$(IW4MAdminBundleName)","version":"$(IW4MAdminBundleVersion)","author":"$(IW4MAdminBundleAuthor)","entryAssembly":"lib/$(TargetFileName)","webRoot":"wwwroot","gscRoot":"gsc","resourceRoot":"resources"}</_IW4MManifest>
         </PropertyGroup>
 
         <RemoveDir Directories="$(_IW4MAdminBundleStage)" />
@@ -168,6 +169,7 @@ foreach (var kv in byClass)
         <ItemGroup>
             <_IW4MWeb Include="$(IW4MAdminWebRoot)\**\*" />
             <_IW4MGsc Include="$(IW4MAdminGscRoot)\**\*" />
+            <_IW4MRes Include="$(IW4MAdminResourceRoot)\**\*" />
         </ItemGroup>
 
         <!-- IW4M1002: duplicate class names across the bundle's hand-written stylesheets (see UsingTask) -->
@@ -181,6 +183,9 @@ foreach (var kv in byClass)
         <Copy Condition="'@(_IW4MGsc)' != ''"
               SourceFiles="@(_IW4MGsc)"
               DestinationFiles="@(_IW4MGsc->'$(_IW4MAdminBundleStage)gsc\%(RecursiveDir)%(Filename)%(Extension)')" />
+        <Copy Condition="'@(_IW4MRes)' != ''"
+              SourceFiles="@(_IW4MRes)"
+              DestinationFiles="@(_IW4MRes->'$(_IW4MAdminBundleStage)resources\%(RecursiveDir)%(Filename)%(Extension)')" />
 
         <MakeDir Directories="$(IW4MAdminBundleOutput)" />
         <ZipDirectory SourceDirectory="$(_IW4MAdminBundleStage)"

--- a/SharedLibraryCore/Plugins/BundleManifest.cs
+++ b/SharedLibraryCore/Plugins/BundleManifest.cs
@@ -24,6 +24,13 @@ public class BundleManifest
     /// <summary>Folder within the bundle whose contents are served at /_content/{id}/. Defaults to "wwwroot".</summary>
     public string WebRoot { get; set; } = "wwwroot";
 
-    /// <summary>Folder within the bundle holding game-side scripts extracted to disk. Defaults to "gsc".</summary>
+    /// <summary>Folder within the bundle holding game-side scripts, extracted to the plugin's sandbox
+    /// (<c>Plugins/&lt;id&gt;/gsc/</c>) on load for the instance owner to copy to their game server.
+    /// Defaults to "gsc".</summary>
     public string GscRoot { get; set; } = "gsc";
+
+    /// <summary>Folder within the bundle whose contents are extracted to the plugin's own data folder
+    /// (<c>Plugins/&lt;id&gt;/Resources/</c>) on load. Lets a plugin ship arbitrary data files (databases,
+    /// assets, …) and read them from disk at runtime without any operator setup. Defaults to "resources".</summary>
+    public string ResourceRoot { get; set; } = "resources";
 }

--- a/SharedLibraryCore/Plugins/LoadedBundle.cs
+++ b/SharedLibraryCore/Plugins/LoadedBundle.cs
@@ -4,8 +4,8 @@ namespace SharedLibraryCore.Plugins;
 
 /// <summary>
 /// Result of loading a plugin bundle: the loaded assembly plus its parsed manifest and resources.
-/// Web assets are held in memory (served via the asset store); GSC files are surfaced for optional
-/// extraction to the configured game-files folder.
+/// Web assets are held in memory (served via the asset store); GSC files and resource files are surfaced
+/// for extraction to the plugin's own sandbox folder.
 /// </summary>
 public sealed class LoadedBundle
 {
@@ -15,5 +15,12 @@ public sealed class LoadedBundle
     public required Assembly Assembly { get; init; }
     public required BundleManifest Manifest { get; init; }
     public required IReadOnlyDictionary<string, byte[]> WebAssets { get; init; }
+
+    /// <summary>Game-side scripts, keyed by path relative to the gsc root. Extracted to the plugin's sandbox
+    /// (<c>Plugins/&lt;id&gt;/gsc/</c>) on load; the instance owner copies them to their game server.</summary>
     public required IReadOnlyDictionary<string, byte[]> GscFiles { get; init; }
+
+    /// <summary>Generic bundle data files, keyed by path relative to the bundle's resource root. Extracted to
+    /// the plugin's sandbox folder (<c>Plugins/&lt;id&gt;/Resources/</c>) by the host on load.</summary>
+    public required IReadOnlyDictionary<string, byte[]> ResourceFiles { get; init; }
 }

--- a/SharedLibraryCore/Plugins/PluginBundleLoader.cs
+++ b/SharedLibraryCore/Plugins/PluginBundleLoader.cs
@@ -107,9 +107,10 @@ public sealed class PluginBundleLoader(IPluginAssetStorage assetStore) : IPlugin
                 var libAssemblies = ReadFolder(archive, LibFolder(manifest));
                 var webAssets = ReadFolder(archive, manifest.WebRoot);
                 var gscFiles = ReadFolder(archive, manifest.GscRoot);
+                var resourceFiles = ReadFolder(archive, manifest.ResourceRoot);
 
                 var assembly = LoadEntryInMemory(manifest, libAssemblies);
-                var loaded = RegisterBundle(manifest, assembly, webAssets, gscFiles);
+                var loaded = RegisterBundle(manifest, assembly, webAssets, gscFiles, resourceFiles);
                 Logger?.LogDebug(
                     "Plugin bundle '{Id}' via {Source}: loaded fresh — assembly v{AssemblyVersion}, manifest version '{ManifestVersion}', {AssetCount} web asset(s)",
                     manifest.Id, sourceLabel, assembly.GetName().Version, manifest.Version, webAssets.Count);
@@ -149,10 +150,11 @@ public sealed class PluginBundleLoader(IPluginAssetStorage assetStore) : IPlugin
                 var libAssemblies = ReadDirectory(directory, LibFolder(manifest));
                 var webAssets = ReadDirectory(directory, manifest.WebRoot);
                 var gscFiles = ReadDirectory(directory, manifest.GscRoot);
+                var resourceFiles = ReadDirectory(directory, manifest.ResourceRoot);
 
                 // load in-memory (same path as the zip/premium channel) so local and remote behave identically
                 var assembly = LoadEntryInMemory(manifest, libAssemblies);
-                var loaded = RegisterBundle(manifest, assembly, webAssets, gscFiles);
+                var loaded = RegisterBundle(manifest, assembly, webAssets, gscFiles, resourceFiles);
                 Logger?.LogDebug(
                     "Plugin bundle '{Id}' via {Source}: loaded fresh — assembly v{AssemblyVersion}, manifest version '{ManifestVersion}', {AssetCount} web asset(s)",
                     manifest.Id, directory, assembly.GetName().Version, manifest.Version, webAssets.Count);
@@ -205,7 +207,8 @@ public sealed class PluginBundleLoader(IPluginAssetStorage assetStore) : IPlugin
     }
 
     private LoadedBundle RegisterBundle(BundleManifest manifest, Assembly assembly,
-        IReadOnlyDictionary<string, byte[]> webAssets, IReadOnlyDictionary<string, byte[]> gscFiles)
+        IReadOnlyDictionary<string, byte[]> webAssets, IReadOnlyDictionary<string, byte[]> gscFiles,
+        IReadOnlyDictionary<string, byte[]> resourceFiles)
     {
         // Scope every CSS asset to this plugin's marker before it is served, so the plugin's styles
         // apply only inside its own rendered subtree and can't disturb the host chrome. See
@@ -218,7 +221,8 @@ public sealed class PluginBundleLoader(IPluginAssetStorage assetStore) : IPlugin
             Assembly = assembly,
             Manifest = manifest,
             WebAssets = servedAssets,
-            GscFiles = gscFiles
+            GscFiles = gscFiles,
+            ResourceFiles = resourceFiles
         };
 
         _cache[manifest.Id] = bundle;

--- a/SharedLibraryCore/Utilities.cs
+++ b/SharedLibraryCore/Utilities.cs
@@ -1356,8 +1356,9 @@ namespace SharedLibraryCore
         /// (<c>Plugins/&lt;plugin&gt;/&lt;name&gt;.db</c>, derived from <typeparamref name="TContext"/>'s
         /// assembly); <paramref name="name"/> defaults to the context type name and may contain
         /// forward-slash subfolders. Injects an isolated <see cref="IDbContextFactory{TContext}"/> and
-        /// records a migration that the host applies at startup (before the plugin's <c>Load</c>). A
-        /// plugin may register more than one database.
+        /// records a <see cref="PluginDatabaseRegistration"/> (pure data — path plus a context accessor)
+        /// that the host applies at startup (before the plugin's <c>Load</c>); the host owns the migrate
+        /// and WAL setup. A plugin may register more than one database.
         /// </summary>
         public static IServiceCollection AddDatabase<TContext>(this IServiceCollection serviceCollection,
             string name = null) where TContext : DbContext
@@ -1372,14 +1373,7 @@ namespace SharedLibraryCore
             serviceCollection.AddSingleton(new PluginDatabaseRegistration(
                 typeof(TContext).Name,
                 databasePath,
-                async token =>
-                {
-                    await using var context = factory.CreateDbContext();
-                    await context.Database.MigrateAsync(token);
-                    // WAL lets readers proceed during writes; it is a persistent setting, so applying it
-                    // once after migration is enough.
-                    await context.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;", token);
-                }));
+                () => factory.CreateDbContext()));
 
             return serviceCollection;
         }

--- a/SharedLibraryCore/Utilities.cs
+++ b/SharedLibraryCore/Utilities.cs
@@ -6,7 +6,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Data.Models;
 using Humanizer;
+using Microsoft.EntityFrameworkCore;
 using SharedLibraryCore.Configuration;
+using SharedLibraryCore.Database;
 using SharedLibraryCore.Database.Models;
 using SharedLibraryCore.Dtos.Meta;
 using SharedLibraryCore.Events.Game;
@@ -1348,7 +1350,40 @@ namespace SharedLibraryCore
 
             return serviceCollection;
         }
-        
+
+        /// <summary>
+        /// Registers a plugin-owned SQLite database. The file lands in the plugin's own data folder
+        /// (<c>Plugins/&lt;plugin&gt;/&lt;name&gt;.db</c>, derived from <typeparamref name="TContext"/>'s
+        /// assembly); <paramref name="name"/> defaults to the context type name and may contain
+        /// forward-slash subfolders. Injects an isolated <see cref="IDbContextFactory{TContext}"/> and
+        /// records a migration that the host applies at startup (before the plugin's <c>Load</c>). A
+        /// plugin may register more than one database.
+        /// </summary>
+        public static IServiceCollection AddDatabase<TContext>(this IServiceCollection serviceCollection,
+            string name = null) where TContext : DbContext
+        {
+            var directory = PluginDirectoryResolver.ResolveDirectory(typeof(TContext).Assembly);
+            var databasePath =
+                PluginDirectoryResolver.CombineWithinRoot(directory, name ?? typeof(TContext).Name, ".db");
+            var factory = new PluginDbContextFactory<TContext>($"Data Source={databasePath}");
+
+            serviceCollection.AddSingleton<IDbContextFactory<TContext>>(factory);
+
+            serviceCollection.AddSingleton(new PluginDatabaseRegistration(
+                typeof(TContext).Name,
+                databasePath,
+                async token =>
+                {
+                    await using var context = factory.CreateDbContext();
+                    await context.Database.MigrateAsync(token);
+                    // WAL lets readers proceed during writes; it is a persistent setting, so applying it
+                    // once after migration is enough.
+                    await context.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;", token);
+                }));
+
+            return serviceCollection;
+        }
+
         public static TimeSpan GetExponentialBackoffDelay(int retryCount, int staticDelay = 5)
         {
             var maxTimeout = TimeSpan.FromMinutes(2.1);

--- a/WebfrontCore/Components/UI/Layout/NavMenu.razor
+++ b/WebfrontCore/Components/UI/Layout/NavMenu.razor
@@ -97,7 +97,7 @@
             {
                 <NavLink href="@pageLink.Location" @onclick="CloseMobileMenu"
                          class="group flex items-center px-3 py-2 text-sm font-medium rounded-md text-subtle hover:bg-surface-hover hover:text-foreground transition-colors [&.active]:bg-action-primary [&.active]:text-foreground [&.active]:hover:bg-action-primary-hover">
-                    <i class="ph @(pageLink.Location.EndsWith("radar") ? "ph-wifi-high" : pageLink.Location.EndsWith("zombies") ? "ph-skull" : "ph-chart-bar") mr-3 text-lg text-secondary group-hover:text-foreground group-[.active]:text-foreground"></i>
+                    <i class="ph @(string.IsNullOrWhiteSpace(pageLink.IconId) ? "ph-chart-bar" : pageLink.IconId) mr-3 text-lg text-secondary group-hover:text-foreground group-[.active]:text-foreground"></i>
                     <span class="truncate">@pageLink.Name</span>
                 </NavLink>
             }

--- a/WebfrontCore/Core/Services/WebfrontDataService.cs
+++ b/WebfrontCore/Core/Services/WebfrontDataService.cs
@@ -294,10 +294,15 @@ public class WebfrontDataService : IWebfrontDataService
 
     public async Task<NavigationInfo> GetNavigationDataAsync()
     {
-        // Get pages from Manager's page list (IDictionary<string, string> where key=name, value=location)
-        var rawPages = _manager.GetPageList().Pages;
-        var pages = rawPages
-            .Select(kvp => new Page { Name = kvp.Key, Location = kvp.Value })
+        // Get pages from Manager's page list (key=name, value=location), plus any per-page navbar icon
+        var pageList = _manager.GetPageList();
+        var pages = pageList.Pages
+            .Select(kvp => new Page
+            {
+                Name = kvp.Key,
+                Location = kvp.Value,
+                IconId = pageList.PageIcons.TryGetValue(kvp.Key, out var icon) ? icon : null
+            })
             .ToList();
 
         // Get all navigation interactions (Main, Admin, Social)
@@ -331,7 +336,7 @@ public class WebfrontDataService : IWebfrontDataService
             User = user,
             Authorized = authorized,
             Pages = pages
-                .Select(page => new Page { Name = page.Name, Location = page.Location }),
+                .Select(page => new Page { Name = page.Name, Location = page.Location, IconId = page.IconId }),
             Interactions = interactions
                 .Select(i => new NavigationInteractionInfo
                 {

--- a/docs/plugin-data-directories.md
+++ b/docs/plugin-data-directories.md
@@ -1,0 +1,272 @@
+# Plugin data: config, databases, and files
+
+Every IW4MAdmin plugin gets its own isolated folder on disk — `Plugins/<YourPlugin>/` — for its
+config files, its own database, and any other files it owns. You never compose paths by hand; the
+host derives the folder from your plugin and routes everything into it.
+
+This guide uses the **Credify** plugin as the worked example.
+
+---
+
+## TL;DR
+
+```csharp
+public class Plugin : IPluginV2
+{
+    public static void RegisterDependencies(IServiceCollection services)
+    {
+        services.AddConfiguration<MyConfiguration>();   // → Plugins/MyPlugin/MyConfiguration.json
+        services.AddDatabase<MyDbContext>();            // → Plugins/MyPlugin/MyDbContext.db
+    }
+
+    // inject your config (loaded) and a context factory (migrated)
+    public Plugin(MyConfiguration config, IDbContextFactory<MyDbContext> dbFactory) { }
+}
+```
+
+- Folder name comes from your plugin automatically — no key, no path string.
+- Configs save/load/hot-reload as before, just inside your folder.
+- Databases get a connection string, an isolated factory, automatic migrations, and WAL — for free.
+- Want a raw file? Inject `IPluginDataDirectory<Plugin>` and call `GetPath(...)`.
+
+---
+
+## 1. Configuration
+
+Write a config type and register it. The file lands in *your* plugin folder.
+
+```csharp
+public class MyConfiguration : IBaseConfiguration
+{
+    public int DailyBonus { get; set; } = 100;
+    public string Name() => nameof(MyConfiguration);
+}
+
+public static void RegisterDependencies(IServiceCollection services)
+{
+    services.AddConfiguration<MyConfiguration>();          // file = MyConfiguration.json
+    // or a custom file name:
+    services.AddConfiguration<MyConfiguration>("Settings"); // file = Settings.json
+}
+
+public Plugin(MyConfiguration config)
+{
+    var bonus = config.DailyBonus;   // already loaded from disk (default written on first run)
+}
+```
+
+The host knows it's *your* config because `MyConfiguration` is defined in your plugin. Save, load,
+and hot-reload behave exactly as they did before — only the location changed.
+
+> **Tip (obfuscated/premium plugins):** if your build obfuscates type names, pass an explicit file
+> name (`AddConfiguration<MyConfiguration>("Settings")`) so the file name stays stable across builds.
+> Your folder name is always stable.
+
+---
+
+## 2. A database of your own
+
+Plugins can own a SQLite database, fully separate from the host's database (the host may run
+Postgres or MySQL — yours stays SQLite, with its own migration history, never FK'd into host tables).
+
+### 2.1 Entities
+
+Plain POCOs — your schema, your rules. Store client ids as bare ints; resolve names at runtime via
+the host.
+
+```csharp
+public class PlayerWallet
+{
+    public int Id { get; set; }
+    public int ClientId { get; set; }   // not an FK into host tables
+    public long Balance { get; set; }
+}
+```
+
+### 2.2 Context
+
+Give the context two constructors: the host calls the options overload at runtime; `dotnet ef` falls
+back to the parameterless one at design time, where `OnConfiguring` hands it just the provider shape.
+
+```csharp
+public class MyDbContext : DbContext
+{
+    // Runtime: the host's AddDatabase<MyDbContext> factory passes the sandboxed SQLite options.
+    public MyDbContext(DbContextOptions<MyDbContext> options) : base(options) { }
+
+    // Design-time: `dotnet ef` constructs this with no host, no DI.
+    public MyDbContext() { }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+    {
+        // Only fires at design time (the runtime options are already configured). No connection string
+        // and no throwaway file — `migrations add` never connects; it only needs the provider services
+        // to diff your model.
+        if (!options.IsConfigured)
+            options.UseSqlite();
+    }
+
+    public DbSet<PlayerWallet> Wallets => Set<PlayerWallet>();
+
+    protected override void OnModelCreating(ModelBuilder b)
+    {
+        b.Entity<PlayerWallet>().HasIndex(w => w.ClientId).IsUnique();
+    }
+}
+```
+
+### 2.3 The EF design-time package
+
+Generating migrations uses standard EF tooling (`dotnet ef`), so your plugin references the EF design
+package — privately, as a dev-only dependency that never ships at runtime or flows to consumers:
+
+```xml
+<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*" PrivateAssets="all" />
+```
+
+That is the **only** design-time plumbing you need. You do not write an
+`IDesignTimeDbContextFactory` — with none present, `dotnet ef` constructs your context through its
+parameterless constructor (2.2) and `OnConfiguring` supplies the provider. No factory class, no
+throwaway `design.db` file.
+
+> **How EF finds your context.** Offline, `dotnet ef` tries an `IDesignTimeDbContextFactory<T>` first,
+> then the app's host builder, then the context's own constructor. A plugin library has neither of the
+> first two, so tooling falls to the parameterless ctor — which is exactly what 2.2 provides.
+
+### 2.4 Register
+
+One line. The host supplies the path, an isolated factory, migrations, and WAL.
+
+```csharp
+public static void RegisterDependencies(IServiceCollection services)
+{
+    services.AddDatabase<MyDbContext>();   // → Plugins/MyPlugin/MyDbContext.db
+}
+
+public Plugin(IDbContextFactory<MyDbContext> dbFactory)
+{
+    // ready to use; schema already migrated before your OnLoad runs
+}
+
+private async Task DoWork(IDbContextFactory<MyDbContext> dbFactory, CancellationToken token)
+{
+    await using var db = await dbFactory.CreateDbContextAsync(token);
+    var wallet = await db.Wallets.FirstOrDefaultAsync(w => w.ClientId == 42, token);
+}
+```
+
+You do **not** write a connection string, a hand-rolled factory, a migrate-on-load call, or WAL
+setup. The host does all of it.
+
+### 2.5 Multiple databases
+
+Allowed. The default file name is the context type; pass a name to disambiguate.
+
+```csharp
+services.AddDatabase<MyDbContext>();             // MyDbContext.db
+services.AddDatabase<AnalyticsDbContext>("stats"); // stats.db  (same plugin folder)
+```
+
+---
+
+## 3. Migrations
+
+Authoring migrations is standard EF — run it at development time against your context:
+
+```bash
+dotnet ef migrations add AddWallets \
+  -p MyPlugin/MyPlugin.csproj -s MyPlugin/MyPlugin.csproj \
+  -c MyPlugin.MyDbContext
+```
+
+This produces a `Migrations/` folder that compiles into your plugin DLL. At runtime the host applies
+any pending migrations automatically, on startup, before your `OnLoad` — you write no apply code.
+
+Your migration history lives in your own `.db`. It never touches the host's migration history or the
+host's database provider.
+
+> If a migration fails, only **your** database is disabled and the failure is logged once — the host
+> and other plugins keep running.
+
+---
+
+## 4. Raw files
+
+Your plugin folder is a **real directory you fully own** — build whatever subfolder structure you
+need under it. Inject your data directory and resolve paths inside it, using your own plugin type as
+the marker:
+
+```csharp
+public Plugin(IPluginDataDirectory<Plugin> data)
+{
+    var cache  = data.GetPath("cache", "tokens.bin");          // Plugins/MyPlugin/cache/tokens.bin
+    var player = data.GetPath("playerdata", "42", "stats.json"); // nested dirs created for you
+    // ... read/write freely
+}
+```
+
+- `RootPath` — your folder, created on first access.
+- `GetPath(params string[])` — resolves inside your folder, **creating any intermediate
+  directories**; rejects paths that try to escape your folder.
+- `EnsureAsset(name, overwrite)` — copies a resource embedded in your DLL out to your folder on first
+  run (handy for seeding a default file or a folder of assets); nested resource paths are supported.
+
+You can also push a config or database into a subfolder by putting a path in the name:
+
+```csharp
+services.AddDatabase<MyDbContext>("data/wallets");   // → Plugins/MyPlugin/data/wallets.db
+services.AddConfiguration<MyConfiguration>("config/main"); // → Plugins/MyPlugin/config/main.json
+```
+
+---
+
+## 5. Where it all lands
+
+Your data folder sits in `Plugins/` right next to your DLL. A basic plugin stays flat; a larger one
+nests however it likes — both live under the same owned folder:
+
+```
+Plugins/
+├── MyPlugin.dll                 ← your binary
+├── MyPlugin/                    ← your owned data folder
+│   ├── MyConfiguration.json
+│   ├── MyDbContext.db
+│   ├── MyDbContext.db-wal
+│   ├── cache/
+│   │   └── tokens.bin
+│   └── playerdata/
+│       └── 42/stats.json
+├── Credify.dll
+└── Credify/
+    ├── CredifyConfiguration.json   (+ the rest)
+    └── Credify.db
+```
+
+---
+
+## 6. Migrating an existing plugin
+
+When you switch a config from the old shared `Configuration/` folder to `AddConfiguration` routing,
+the host moves your existing file into your plugin folder once, on next start. No data loss, nothing
+to do by hand.
+
+Databases are not auto-moved (a live SQLite file has `-wal`/`-shm` sidecars). If you already ship a
+database in the shared `Database/` folder, point it at the new location yourself before your first
+query, or start fresh.
+
+---
+
+## 7. FAQ
+
+**Why is the folder named after my assembly and not my `Name` property?**
+Your `Name` ("Simple Stats") is a display string with spaces; the assembly name (`Stats`) is stable,
+path-safe, and already how the host identifies your plugin internally. It also stays put under
+obfuscation.
+
+**Can I share a config type between two plugins?**
+Avoid it. The folder is derived from where the type is *defined*, so a type in a shared library would
+route both plugins into the shared library's folder. Define config and context types in your own
+plugin.
+
+**Does any of this break my existing plugin?**
+No. If you don't call the new APIs, nothing changes. Adoption is opt-in, one registration at a time.

--- a/docs/plugin-data-directories.md
+++ b/docs/plugin-data-directories.md
@@ -27,7 +27,7 @@ public class Plugin : IPluginV2
 - Folder name comes from your plugin automatically — no key, no path string.
 - Configs save/load/hot-reload as before, just inside your folder.
 - Databases get a connection string, an isolated factory, automatic migrations, and WAL — for free.
-- Want a raw file? Inject `IPluginDataDirectory<Plugin>` and call `GetPath(...)`.
+- Want a raw file? Inject `IPluginDataStore<Plugin>` and call `GetPath(...)`.
 
 ---
 
@@ -197,7 +197,7 @@ need under it. Inject your data directory and resolve paths inside it, using you
 the marker:
 
 ```csharp
-public Plugin(IPluginDataDirectory<Plugin> data)
+public Plugin(IPluginDataStore<Plugin> data)
 {
     var cache  = data.GetPath("cache", "tokens.bin");          // Plugins/MyPlugin/cache/tokens.bin
     var player = data.GetPath("playerdata", "42", "stats.json"); // nested dirs created for you

--- a/docs/plugin-web-bundles.md
+++ b/docs/plugin-web-bundles.md
@@ -226,11 +226,13 @@ SharedLibraryCore reference is made private automatically, so its closure is nev
 > host-provided exclusion list to avoid re-bundling the host's closure. Until then, such a plugin should
 > ship those deps alongside, or they must already be provided by the host.
 
-## 7. Game scripts (GSC)
+## 7. Bundle resources & game scripts
 
-Put game-side scripts in a `gsc/` folder; they're carried in the bundle and, if the host's
-`PluginGscExtractPath` is configured, extracted there on load. GSC is the only bundle content written to
-disk (it has to reach the game server); the plugin dll and web assets stay in memory.
+Files a plugin needs on disk at runtime go in a `resources/` folder; on load the host extracts them to the
+plugin's own sandbox (`Plugins/<id>/Resources/`), so a deployed bundle is self-contained — a plugin can ship a
+database or data file and open it from there with no operator setup. Game-side scripts work the same way: put
+them in a `gsc/` folder and they're extracted to `Plugins/<id>/gsc/` for the instance owner to copy onto their
+game server. Neither is delivered to any shared location; the plugin dll and web assets stay in memory.
 
 ## 8. Installing
 


### PR DESCRIPTION
## What
Each plugin gets an isolated `Plugins/<key>/` folder for its config, its own database, and any files it owns — instead of everything landing in the shared `Configuration/` and `Database/` folders. Three opt-in surfaces, all keyed off the plugin automatically:

```csharp
public static void RegisterDependencies(IServiceCollection services)
{
    services.AddConfiguration<MySettings>();                    // → Plugins/MyPlugin/MySettings.json
    services.AddConfiguration<MyTranslations>("translations");  // custom name → translations.json
    services.AddDatabase<MyDbContext>();                        // → Plugins/MyPlugin/MyDbContext.db (migrated + WAL)
}
```

For raw files, inject `IPluginDataDirectory<MyPlugin>`:

```csharp
string RootPath { get; }                        // Plugins/<key>/, created on first access
string GetPath(params string[] segments);       // resolve inside the folder; makes intermediate dirs; rejects ../ escape
Task<string> EnsureAsset(string resource, bool overwrite = false);  // copy an embedded resource out to the folder

// var cache = data.GetPath("cache", "tokens.bin");  → Plugins/MyPlugin/cache/tokens.bin (dirs created for you)
```

## Why
- `Configuration/` is a flat mix of host and every plugin's files (Credify alone ships ~30).
- A plugin with its own DB currently hand-rolls a path, a private-options `IDbContextFactory` (to dodge the non-generic `DbContextOptions` collision with the host context), migrate-on-load and WAL. `AddDatabase<T>` absorbs all of it.
- A plugin that just wants to drop a file on disk has no sanctioned home — it composes paths off `OperatingDirectory` by hand.

## How
- **Identity** comes from `typeof(T).Assembly` — no manual keys, no stack-walking. Same for compiled `.dll`, `.cs` scripts, `.zip` bundles, and remote in-memory plugins.
- **Routing by elimination:** host/framework assemblies keep the legacy flat `Configuration/`; everything else is a plugin.
- A plugin can register more than one config (settings, translations, …); the `name` argument disambiguates and may contain `/` to nest into a subfolder.
- **Migrations run before the plugin `Load` event;** a failed one disables only that plugin's DB, logged once.

## Compatibility
Additive and opt-in. A plugin that calls none of these — and the host's own configs — behave exactly as today. V2 configs auto-move out of `Configuration/` on first run; legacy V1 untouched.

Author guide: `docs/plugin-data-directories.md`. Validated end-to-end against Credify (config + its own SQLite DB) in its own repo — a net deletion of boilerplate there.
